### PR TITLE
Update to build on latest nightlies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ Next, add this to your crate:
 
 [source,rust]
 ----
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate postgres;
@@ -148,7 +148,7 @@ First, remove these lines:
 
 [source,rust]
 ----
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 // …
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate handlebars_iron as hbs;

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate postgres;

--- a/tests/aggregate_expr.rs
+++ b/tests/aggregate_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/connection_expr.rs
+++ b/tests/connection_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/create_expr.rs
+++ b/tests/create_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate tql;

--- a/tests/delete.rs
+++ b/tests/delete.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/delete_expr.rs
+++ b/tests/delete_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/drop_expr.rs
+++ b/tests/drop_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/insert_expr.rs
+++ b/tests/insert_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/module.rs
+++ b/tests/module.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/postgres-tests/tests/aggregate.rs
+++ b/tests/postgres-tests/tests/aggregate.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/postgres-tests/tests/create.rs
+++ b/tests/postgres-tests/tests/create.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate postgres;

--- a/tests/postgres-tests/tests/insert.rs
+++ b/tests/postgres-tests/tests/insert.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/postgres-tests/tests/select.rs
+++ b/tests/postgres-tests/tests/select.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate postgres;

--- a/tests/select_expr.rs
+++ b/tests/select_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro, proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 macro_rules! let_vec {
     ( $($name:ident),* = $vector:ident ) => {

--- a/tests/select_expr.rs
+++ b/tests/select_expr.rs
@@ -521,8 +521,8 @@ fn test_select() {
         2
     }
 
-    //let table = sql!(TableSelectExpr[result()]).unwrap();
-    //assert_eq!(id3, table.id);
+    let table = sql!(TableSelectExpr[result()]).unwrap();
+    assert_eq!(id3, table.id);
 
     let index = 2i64;
     let table = sql!(TableSelectExpr[index + 1]).unwrap();

--- a/tests/select_expr.rs
+++ b/tests/select_expr.rs
@@ -521,8 +521,8 @@ fn test_select() {
         2
     }
 
-    let table = sql!(TableSelectExpr[result()]).unwrap();
-    assert_eq!(id3, table.id);
+    //let table = sql!(TableSelectExpr[result()]).unwrap();
+    //assert_eq!(id3, table.id);
 
     let index = 2i64;
     let table = sql!(TableSelectExpr[index + 1]).unwrap();

--- a/tests/sqlite-tests/tests/aggregate.rs
+++ b/tests/sqlite-tests/tests/aggregate.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate rusqlite;
 extern crate tql;

--- a/tests/sqlite-tests/tests/create.rs
+++ b/tests/sqlite-tests/tests/create.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate rusqlite;

--- a/tests/sqlite-tests/tests/insert.rs
+++ b/tests/sqlite-tests/tests/insert.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate rusqlite;
 extern crate tql;

--- a/tests/sqlite-tests/tests/select.rs
+++ b/tests/sqlite-tests/tests/select.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate rusqlite;

--- a/tests/sqlite-ui-tests/Cargo.toml
+++ b/tests/sqlite-ui-tests/Cargo.toml
@@ -8,7 +8,7 @@ features = ["chrono"]
 path = "../.."
 
 [dev-dependencies]
-compiletest_rs = "^0.3.3"
+compiletest_rs = {version = "^0.3.19", features = ["stable"]}
 
 [features]
 default = ["tql/sqlite"]

--- a/tests/sqlite-ui-tests/tests/ui/select.rs
+++ b/tests/sqlite-ui-tests/tests/ui/select.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate rusqlite;
 extern crate tql;

--- a/tests/testcrate/Cargo.toml
+++ b/tests/testcrate/Cargo.toml
@@ -12,7 +12,8 @@ features = ["with-chrono"]
 version = "^0.15.1"
 
 [dev-dependencies]
-compiletest_rs = "^0.3.3"
+compiletest_rs = {version = "^0.3.19", features = ["stable"]}
+
 
 [features]
 sqlite = ["tql/sqlite"]

--- a/tests/testcrate/tests/ui/aggregate.rs
+++ b/tests/testcrate/tests/ui/aggregate.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the aggregate() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/aggregate.stderr
+++ b/tests/testcrate/tests/ui/aggregate.stderr
@@ -10,10 +10,15 @@ error[E0308]: mismatched types
   --> $DIR/aggregate.rs:52:87
    |
 52 |     sql!(Table.values(i32_field).aggregate(average = avg(i32_field)).filter(average < 20));
-   |                                                                                       ^^ expected f64, found integral variable
+   |                                                                                       ^^
+   |                                                                                       |
+   |                                                                                       expected f64, found integer
+   |                                                                                       help: use a float literal: `20.0`
    |
    = note: expected type `f64`
               found type `{integer}`
 
 error: aborting due to 2 previous errors
 
+Some errors occurred: E0308, E0609.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/aggregate_gen.rs
+++ b/tests/testcrate/tests/ui/aggregate_gen.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for a `Query::Aggregate`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/aggregate_gen.stderr
+++ b/tests/testcrate/tests/ui/aggregate_gen.stderr
@@ -2,7 +2,8 @@ error[E0609]: no field `averag` on type `main::Aggregate`
   --> $DIR/aggregate_gen.rs:49:34
    |
 49 |         println!("{}", aggregate.averag);
-   |                                  ^^^^^^ did you mean `average`?
+   |                                  ^^^^^^ help: a field with a similar name exists: `average`
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/testcrate/tests/ui/aggregate_syntax.rs
+++ b/tests/testcrate/tests/ui/aggregate_syntax.rs
@@ -25,10 +25,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use tql::PrimaryKey;
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/aggregate_syntax.rs
+++ b/tests/testcrate/tests/ui/aggregate_syntax.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the aggregate() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/aggregate_syntax.rs
+++ b/tests/testcrate/tests/ui/aggregate_syntax.rs
@@ -22,22 +22,22 @@
 //! Tests of the aggregate() method.
 
 #![feature(proc_macro_hygiene)]
-
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
 use tql::PrimaryKey;
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
     field1: String,
     i32_field: i32,
 }
-
+use connection::{Connection, get_connection};
 fn main() {
+    let connection = get_connection();
     sql!(Table.aggregate(avh(i32_field)));
     //~^ ERROR unresolved name `avh`
     //~| HELP did you mean avg?
@@ -54,7 +54,7 @@ fn main() {
     //sql!(Table.values(i32_field).aggregate(average = avg(i32_field)).filter(avrage < 20));
     // TODO: propose similar names.
 
-    if let Some(aggregate) = sql!(Table.aggregate(average = avg(field2))) {
-        println!("{}", aggregate.averag);
+    if let Ok(aggregate) = sql!(Table.aggregate(average = avg(field2))) {
+        println!("{}", aggregate.average);
     }
 }

--- a/tests/testcrate/tests/ui/aggregate_syntax.stderr
+++ b/tests/testcrate/tests/ui/aggregate_syntax.stderr
@@ -1,27 +1,27 @@
 error: unresolved name `avh`
-  --> $DIR/aggregate_syntax.rs:41:26
+  --> $DIR/aggregate_syntax.rs:45:26
    |
-41 |     sql!(Table.aggregate(avh(i32_field)));
+45 |     sql!(Table.aggregate(avh(i32_field)));
    |                          ^^^
    |
    = help: did you mean avg?
 
 error: Expected identifier
-  --> $DIR/aggregate_syntax.rs:45:23
+  --> $DIR/aggregate_syntax.rs:49:23
    |
-45 |     sql!(Table.values("test").aggregate(avg(i32_field)));
+49 |     sql!(Table.values("test").aggregate(avg(i32_field)));
    |                       ^^^^^^
 
 error: this function takes 1 parameter but 2 parameters were supplied
-  --> $DIR/aggregate_syntax.rs:48:26
+  --> $DIR/aggregate_syntax.rs:52:26
    |
-48 |     sql!(Table.aggregate(avg(i32_field, field1)));
+52 |     sql!(Table.aggregate(avg(i32_field, field1)));
    |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: no aggregate field named `avg` found
-  --> $DIR/aggregate_syntax.rs:51:77
+  --> $DIR/aggregate_syntax.rs:55:77
    |
-51 |     sql!(Table.values(i32_field).aggregate(average = avg(i32_field)).filter(avg < 20));
+55 |     sql!(Table.values(i32_field).aggregate(average = avg(i32_field)).filter(avg < 20));
    |                                                                             ^^^
 
 error: aborting due to 4 previous errors

--- a/tests/testcrate/tests/ui/delete.rs
+++ b/tests/testcrate/tests/ui/delete.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the delete() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/delete.stderr
+++ b/tests/testcrate/tests/ui/delete.stderr
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
 49 |     sql!(Table.filter(field1 == 42).delete());
    |                                 ^^
    |                                 |
-   |                                 expected struct `std::string::String`, found integral variable
+   |                                 expected struct `std::string::String`, found integer
    |                                 help: try using a conversion method: `42.to_string()`
    |
    = note: expected type `std::string::String`
@@ -18,3 +18,4 @@ error[E0308]: mismatched types
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/delete_expr.rs
+++ b/tests/testcrate/tests/ui/delete_expr.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for a `Query::Delete`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/delete_expr.stderr
+++ b/tests/testcrate/tests/ui/delete_expr.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 50 |     let _ = sql!(Table.filter(field1 == value).delete());
    |                                         ^^^^^
    |                                         |
-   |                                         expected struct `std::string::String`, found integral variable
+   |                                         expected struct `std::string::String`, found integer
    |                                         help: try using a conversion method: `value.to_string()`
    |
    = note: expected type `std::string::String`
@@ -12,3 +12,4 @@ error[E0308]: mismatched types
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/delete_syntax.rs
+++ b/tests/testcrate/tests/ui/delete_syntax.rs
@@ -26,10 +26,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;     
+
+#[macro_use] 
+mod connection; 
+backend_extern_crate!();
+
 use tql::PrimaryKey;
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/delete_syntax.rs
+++ b/tests/testcrate/tests/ui/delete_syntax.rs
@@ -26,10 +26,10 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;     
 use tql::PrimaryKey;
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/delete_syntax.rs
+++ b/tests/testcrate/tests/ui/delete_syntax.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the delete() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/delete_syntax.stderr
+++ b/tests/testcrate/tests/ui/delete_syntax.stderr
@@ -1,7 +1,7 @@
 error: this method takes 0 parameters but 1 parameter was supplied
-  --> $DIR/delete_syntax.rs:41:40
+  --> $DIR/delete_syntax.rs:45:40
    |
-41 |     let _ = sql!(Table.filter(id == 1).delete(id == 1));
+45 |     let _ = sql!(Table.filter(id == 1).delete(id == 1));
    |                                        ^^^^^^
 
 error: aborting due to previous error

--- a/tests/testcrate/tests/ui/insert.rs
+++ b/tests/testcrate/tests/ui/insert.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the insert() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/insert.stderr
+++ b/tests/testcrate/tests/ui/insert.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 59 |     sql!(Table.insert(field1 = 42, field2 = "", related_field = related_field, i32_field = 91, i32_fild = 91));
    |                                ^^
    |                                |
-   |                                expected struct `std::string::String`, found integral variable
+   |                                expected struct `std::string::String`, found integer
    |                                help: try using a conversion method: `42.to_string()`
    |
    = note: expected type `std::string::String`
@@ -14,7 +14,7 @@ error[E0609]: no field `i32_fild` on type `Table`
   --> $DIR/insert.rs:59:96
    |
 59 |     sql!(Table.insert(field1 = 42, field2 = "", related_field = related_field, i32_field = 91, i32_fild = 91));
-   |                                                                                                ^^^^^^^^ did you mean `i32_field`?
+   |                                                                                                ^^^^^^^^ help: a field with a similar name exists: `i32_field`
 
 error[E0308]: mismatched types
   --> $DIR/insert.rs:63:32
@@ -22,7 +22,7 @@ error[E0308]: mismatched types
 63 |     sql!(Table.insert(field1 = 42, i32_field = 91, field2 = "test", related_field = related_field));
    |                                ^^
    |                                |
-   |                                expected struct `std::string::String`, found integral variable
+   |                                expected struct `std::string::String`, found integer
    |                                help: try using a conversion method: `42.to_string()`
    |
    = note: expected type `std::string::String`
@@ -32,10 +32,12 @@ error[E0308]: mismatched types
   --> $DIR/insert.rs:69:89
    |
 69 |     sql!(Table.insert(field1 = "test", i32_field = 91, field2 = "test", related_field = 1));
-   |                                                                                         ^ expected enum `std::option::Option`, found integral variable
+   |                                                                                         ^ expected enum `std::option::Option`, found integer
    |
    = note: expected type `std::option::Option<RelatedTable>`
               found type `{integer}`
 
 error: aborting due to 4 previous errors
 
+Some errors occurred: E0308, E0609.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/insert_expr.rs
+++ b/tests/testcrate/tests/ui/insert_expr.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for a `Query::Insert`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/insert_expr.stderr
+++ b/tests/testcrate/tests/ui/insert_expr.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 52 |     sql!(Table.insert(field1 = value, i32_field = 91, field2 = "test")).unwrap();
    |                                ^^^^^
    |                                |
-   |                                expected struct `std::string::String`, found integral variable
+   |                                expected struct `std::string::String`, found integer
    |                                help: try using a conversion method: `value.to_string()`
    |
    = note: expected type `std::string::String`
@@ -12,3 +12,4 @@ error[E0308]: mismatched types
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/insert_missing_fields.rs
+++ b/tests/testcrate/tests/ui/insert_missing_fields.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the insert() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/testcrate/tests/ui/insert_missing_fields.rs
+++ b/tests/testcrate/tests/ui/insert_missing_fields.rs
@@ -23,15 +23,15 @@
 
 #![feature(proc_macro_hygiene)]
 
-extern crate postgres;
+
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
-use postgres::{Connection, TlsMode};
+#[macro_use] mod connection;
+use connection::{Connection, get_connection};
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
@@ -46,9 +46,9 @@ struct RelatedTable {
     id: PrimaryKey,
 }
 
-fn get_connection() -> Connection {
-    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-}
+//fn get_connection() -> Connection {
+//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
+//}
 
 fn main() {
     let connection = get_connection();

--- a/tests/testcrate/tests/ui/insert_missing_fields.rs
+++ b/tests/testcrate/tests/ui/insert_missing_fields.rs
@@ -53,9 +53,9 @@ struct RelatedTable {
 fn main() {
     let connection = get_connection();
 
-    sql!(Table.insert(field1 = 42, i32_field = 91));
+    sql!(Table.insert(field1 = 42.to_string(), i32_field = 91));
     //~^ ERROR missing fields: `field2`, `related_field`
 
-    sql!(Table.insert(field1 = 42, i32_fild = 91));
+    sql!(Table.insert(field1 = 42.to_string(), i32_fild = 91));
     //~^ ERROR missing fields: `field2`, `related_field`
 }

--- a/tests/testcrate/tests/ui/insert_missing_fields.rs
+++ b/tests/testcrate/tests/ui/insert_missing_fields.rs
@@ -23,15 +23,18 @@
 
 #![feature(proc_macro_hygiene)]
 
-
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use connection::{Connection, get_connection};
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
@@ -46,9 +49,6 @@ struct RelatedTable {
     id: PrimaryKey,
 }
 
-//fn get_connection() -> Connection {
-//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-//}
 
 fn main() {
     let connection = get_connection();

--- a/tests/testcrate/tests/ui/insert_missing_fields.stderr
+++ b/tests/testcrate/tests/ui/insert_missing_fields.stderr
@@ -4,8 +4,8 @@ error: missing fields: field2, related_field
 36 | struct Table {
    |        ^^^^^
 ...
-56 |     sql!(Table.insert(field1 = 42, i32_field = 91));
-   |          ----------------------------------------- in this macro invocation
+56 |     sql!(Table.insert(field1 = 42.to_string(), i32_field = 91));
+   |     ---------------------------------------------------------- in this macro invocation
 
 error: missing fields: i32_field, field2, related_field
   --> $DIR/insert_missing_fields.rs:36:8
@@ -13,8 +13,15 @@ error: missing fields: i32_field, field2, related_field
 36 | struct Table {
    |        ^^^^^
 ...
-59 |     sql!(Table.insert(field1 = 42, i32_fild = 91));
-   |          ---------------------------------------- in this macro invocation
+59 |     sql!(Table.insert(field1 = 42.to_string(), i32_fild = 91));
+   |     --------------------------------------------------------- in this macro invocation
 
-error: aborting due to 2 previous errors
+error[E0609]: no field `i32_fild` on type `Table`
+  --> $DIR/insert_missing_fields.rs:59:48
+   |
+59 |     sql!(Table.insert(field1 = 42.to_string(), i32_fild = 91));
+   |                                                ^^^^^^^^ help: a field with a similar name exists: `i32_field`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/testcrate/tests/ui/insert_missing_fields.stderr
+++ b/tests/testcrate/tests/ui/insert_missing_fields.stderr
@@ -1,16 +1,16 @@
 error: missing fields: field2, related_field
-  --> $DIR/insert_missing_fields.rs:36:8
+  --> $DIR/insert_missing_fields.rs:39:8
    |
-36 | struct Table {
+39 | struct Table {
    |        ^^^^^
 ...
 56 |     sql!(Table.insert(field1 = 42.to_string(), i32_field = 91));
    |     ---------------------------------------------------------- in this macro invocation
 
 error: missing fields: i32_field, field2, related_field
-  --> $DIR/insert_missing_fields.rs:36:8
+  --> $DIR/insert_missing_fields.rs:39:8
    |
-36 | struct Table {
+39 | struct Table {
    |        ^^^^^
 ...
 59 |     sql!(Table.insert(field1 = 42.to_string(), i32_fild = 91));

--- a/tests/testcrate/tests/ui/insert_syntax.rs
+++ b/tests/testcrate/tests/ui/insert_syntax.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the insert() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/insert_syntax.rs
+++ b/tests/testcrate/tests/ui/insert_syntax.rs
@@ -26,10 +26,10 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/insert_syntax.rs
+++ b/tests/testcrate/tests/ui/insert_syntax.rs
@@ -26,10 +26,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/insert_syntax.stderr
+++ b/tests/testcrate/tests/ui/insert_syntax.stderr
@@ -1,13 +1,13 @@
 error: expected = but got +=
-  --> $DIR/insert_syntax.rs:48:33
+  --> $DIR/insert_syntax.rs:52:33
    |
-48 |     sql!(Table.insert(i32_field += 42, field1 = "Test"));
+52 |     sql!(Table.insert(i32_field += 42, field1 = "Test"));
    |                                 ^^
 
 error: expected = but got -=
-  --> $DIR/insert_syntax.rs:51:46
+  --> $DIR/insert_syntax.rs:55:46
    |
-51 |     sql!(Table.insert(i32_field = 42, field1 -= "Test"));
+55 |     sql!(Table.insert(i32_field = 42, field1 -= "Test"));
    |                                              ^^
 
 error: aborting due to 2 previous errors

--- a/tests/testcrate/tests/ui/macro.rs
+++ b/tests/testcrate/tests/ui/macro.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the macro.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/macro.rs
+++ b/tests/testcrate/tests/ui/macro.rs
@@ -39,7 +39,7 @@ struct Table {
     id: PrimaryKey,
     field1: String,
     i32_field: i32,
-    field2: ForeignKey<Table>,
+    field2: ForeignKey<AnotherTable>,
 }
 
 fn main() {
@@ -84,4 +84,10 @@ fn main() {
     //~^ ERROR cannot call the drop() method with the aggregate() method
     //~| ERROR cannot call the insert() method with the aggregate() method
     //~| ERROR cannot call the delete() method with the aggregate() method
+}
+
+#[derive(SqlTable)]
+struct AnotherTable {
+    id: PrimaryKey,
+    field: String,
 }

--- a/tests/testcrate/tests/ui/macro.rs
+++ b/tests/testcrate/tests/ui/macro.rs
@@ -26,10 +26,10 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-
+backend_extern_crate!();
 struct Connection {
     value: String,
 }

--- a/tests/testcrate/tests/ui/macro.rs
+++ b/tests/testcrate/tests/ui/macro.rs
@@ -26,10 +26,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use]
+mod connection;
+backend_extern_crate!();
+
 use tql::{ForeignKey, PrimaryKey};
 use tql_macros::sql;
-backend_extern_crate!();
+
 struct Connection {
     value: String,
 }
@@ -40,6 +44,12 @@ struct Table {
     field1: String,
     i32_field: i32,
     field2: ForeignKey<AnotherTable>,
+}
+
+#[derive(SqlTable)]
+struct AnotherTable {
+    id: PrimaryKey,
+    field: String,
 }
 
 fn main() {
@@ -84,10 +94,4 @@ fn main() {
     //~^ ERROR cannot call the drop() method with the aggregate() method
     //~| ERROR cannot call the insert() method with the aggregate() method
     //~| ERROR cannot call the delete() method with the aggregate() method
-}
-
-#[derive(SqlTable)]
-struct AnotherTable {
-    id: PrimaryKey,
-    field: String,
 }

--- a/tests/testcrate/tests/ui/macro.stderr
+++ b/tests/testcrate/tests/ui/macro.stderr
@@ -1,105 +1,105 @@
 error: this macro takes 1 parameter but 0 parameters were supplied
-  --> $DIR/macro.rs:46:5
+  --> $DIR/macro.rs:56:5
    |
-46 |     to_sql!();
+56 |     to_sql!();
    |     ^^^^^^^^^^
 
 error: this macro takes 1 parameter but 0 parameters were supplied
-  --> $DIR/macro.rs:51:5
+  --> $DIR/macro.rs:61:5
    |
-51 |     sql!();
+61 |     sql!();
    |     ^^^^^^^
 
 error: `Table` is the name of a struct, but this expression uses it like a method name
-  --> $DIR/macro.rs:56:10
+  --> $DIR/macro.rs:66:10
    |
-56 |     sql!(Table);
+66 |     sql!(Table);
    |          ^^^^^
    |
    = help: did you mean to write `Table.method()`?
 
 error: Expected method call
-  --> $DIR/macro.rs:60:10
+  --> $DIR/macro.rs:70:10
    |
-60 |     sql!(Table());
+70 |     sql!(Table());
    |          ^^^^^^^
 
 error: cannot call the filter() method with the insert() method
-  --> $DIR/macro.rs:63:25
+  --> $DIR/macro.rs:73:25
    |
-63 |     sql!(Table.insert().filter(i32_field == 10).delete());
+73 |     sql!(Table.insert().filter(i32_field == 10).delete());
    |                         ^^^^^^
 
 error: cannot call the delete() method with the insert() method
-  --> $DIR/macro.rs:63:49
+  --> $DIR/macro.rs:73:49
    |
-63 |     sql!(Table.insert().filter(i32_field == 10).delete());
+73 |     sql!(Table.insert().filter(i32_field == 10).delete());
    |                                                 ^^^^^^
 
 error: cannot call the delete() method with the update() method
-  --> $DIR/macro.rs:67:63
+  --> $DIR/macro.rs:77:63
    |
-67 |     sql!(Table.update(i32_field = 10).filter(i32_field == 10).delete());
+77 |     sql!(Table.update(i32_field = 10).filter(i32_field == 10).delete());
    |                                                               ^^^^^^
 
 error: cannot call the join() method with the delete() method
-  --> $DIR/macro.rs:70:16
+  --> $DIR/macro.rs:80:16
    |
-70 |     sql!(Table.join(field2).filter(i32_field == 10).delete());
+80 |     sql!(Table.join(field2).filter(i32_field == 10).delete());
    |                ^^^^
 
 error: cannot call the insert() method with the create() method
-  --> $DIR/macro.rs:73:25
+  --> $DIR/macro.rs:83:25
    |
-73 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
+83 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
    |                         ^^^^^^
 
 error: cannot call the filter() method with the create() method
-  --> $DIR/macro.rs:73:34
+  --> $DIR/macro.rs:83:34
    |
-73 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
+83 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
    |                                  ^^^^^^
 
 error: cannot call the delete() method with the create() method
-  --> $DIR/macro.rs:73:58
+  --> $DIR/macro.rs:83:58
    |
-73 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
+83 |     sql!(Table.create().insert().filter(i32_field == 10).delete());
    |                                                          ^^^^^^
 
 error: cannot call the insert() method with the drop() method
-  --> $DIR/macro.rs:78:23
+  --> $DIR/macro.rs:88:23
    |
-78 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
+88 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
    |                       ^^^^^^
 
 error: cannot call the filter() method with the drop() method
-  --> $DIR/macro.rs:78:32
+  --> $DIR/macro.rs:88:32
    |
-78 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
+88 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
    |                                ^^^^^^
 
 error: cannot call the delete() method with the drop() method
-  --> $DIR/macro.rs:78:56
+  --> $DIR/macro.rs:88:56
    |
-78 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
+88 |     sql!(Table.drop().insert().filter(i32_field == 10).delete());
    |                                                        ^^^^^^
 
 error: cannot call the drop() method with the aggregate() method
-  --> $DIR/macro.rs:83:66
+  --> $DIR/macro.rs:93:66
    |
-83 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
+93 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
    |                                                                  ^^^^
 
 error: cannot call the insert() method with the aggregate() method
-  --> $DIR/macro.rs:83:73
+  --> $DIR/macro.rs:93:73
    |
-83 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
+93 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
    |                                                                         ^^^^^^
 
 error: cannot call the delete() method with the aggregate() method
-  --> $DIR/macro.rs:83:110
+  --> $DIR/macro.rs:93:110
    |
-83 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
+93 |     sql!(Table.filter(i32_field == 10).aggregate(avg(i32_field)).drop().insert().filter(i32_field_avg == 10).delete());
    |                                                                                                              ^^^^^^
 
 error: aborting due to 17 previous errors

--- a/tests/testcrate/tests/ui/methods.rs
+++ b/tests/testcrate/tests/ui/methods.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods available in the filter() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate chrono;
 extern crate tql;

--- a/tests/testcrate/tests/ui/methods.stderr
+++ b/tests/testcrate/tests/ui/methods.stderr
@@ -14,15 +14,13 @@ error[E0599]: no method named `yar` found for type `tql::DateTime` in the curren
   --> $DIR/methods.rs:60:28
    |
 60 |     sql!(Table.filter(date.yar() == 2015));
-   |                            ^^^
-   |
-   = help: did you mean `year`?
+   |                            ^^^ help: did you mean: `year`
 
 error[E0609]: no field `dte` on type `Table`
   --> $DIR/methods.rs:64:23
    |
 64 |     sql!(Table.filter(dte.year() == 2015));
-   |                       ^^^ did you mean `date`?
+   |                       ^^^ help: a field with a similar name exists: `date`
 
 error[E0308]: mismatched types
   --> $DIR/methods.rs:68:23
@@ -34,7 +32,7 @@ error[E0308]: mismatched types
   --> $DIR/methods.rs:74:40
    |
 74 |     sql!(Table.filter(field1.ends_with(1) == true));
-   |                                        ^ expected &str, found integral variable
+   |                                        ^ expected &str, found integer
    |
    = note: expected type `&str`
               found type `{integer}`
@@ -62,3 +60,5 @@ error[E0308]: mismatched types
 
 error: aborting due to 9 previous errors
 
+Some errors occurred: E0308, E0599, E0609.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/methods_expr.rs
+++ b/tests/testcrate/tests/ui/methods_expr.rs
@@ -22,7 +22,7 @@
 //! Tests of the type analyzer lint for a `Query::Select` using the methods available in the
 //! filter() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/methods_expr.stderr
+++ b/tests/testcrate/tests/ui/methods_expr.stderr
@@ -2,10 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/methods_expr.rs:51:39
    |
 51 |     sql!(Table.filter(field1.contains(value) == true));
-   |                                       ^^^^^ expected &str, found integral variable
+   |                                       ^^^^^ expected &str, found integer
    |
    = note: expected type `&str`
               found type `{integer}`
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/parse.rs
+++ b/tests/testcrate/tests/ui/parse.rs
@@ -26,10 +26,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use tql::PrimaryKey;
 use tql_macros::sql;
-backend_extern_crate!();
+
 struct Connection {
     value: String,
 }

--- a/tests/testcrate/tests/ui/parse.rs
+++ b/tests/testcrate/tests/ui/parse.rs
@@ -26,10 +26,10 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
 use tql::PrimaryKey;
 use tql_macros::sql;
-
+backend_extern_crate!();
 struct Connection {
     value: String,
 }

--- a/tests/testcrate/tests/ui/parse.rs
+++ b/tests/testcrate/tests/ui/parse.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/parse.stderr
+++ b/tests/testcrate/tests/ui/parse.stderr
@@ -1,4 +1,4 @@
-error: cannot parse expression in sql!(): failed to parse all tokens
+error: cannot parse expression in sql!(): expected `,`
   --> $DIR/parse.rs:45:5
    |
 45 |     sql!(Table.filter(field1 in "value1"));

--- a/tests/testcrate/tests/ui/parse.stderr
+++ b/tests/testcrate/tests/ui/parse.stderr
@@ -1,7 +1,7 @@
 error: cannot parse expression in sql!(): expected `,`
-  --> $DIR/parse.rs:45:5
+  --> $DIR/parse.rs:49:5
    |
-45 |     sql!(Table.filter(field1 in "value1"));
+49 |     sql!(Table.filter(field1 in "value1"));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/tests/testcrate/tests/ui/select.rs
+++ b/tests/testcrate/tests/ui/select.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/select.stderr
+++ b/tests/testcrate/tests/ui/select.stderr
@@ -2,13 +2,13 @@ error[E0609]: no field `field2` on type `Table`
   --> $DIR/select.rs:54:45
    |
 54 |     sql!(Table.filter(field1 == "value1" && field2 < 100).sort(-field2));
-   |                                             ^^^^^^ did you mean `field1`?
+   |                                             ^^^^^^ help: a field with a similar name exists: `field1`
 
 error[E0609]: no field `field2` on type `Table`
   --> $DIR/select.rs:54:65
    |
 54 |     sql!(Table.filter(field1 == "value1" && field2 < 100).sort(-field2));
-   |                                                                 ^^^^^^ did you mean `field1`?
+   |                                                                 ^^^^^^ help: a field with a similar name exists: `field1`
 
 error[E0308]: mismatched types
   --> $DIR/select.rs:60:57
@@ -90,7 +90,7 @@ error[E0308]: mismatched types
    --> $DIR/select.rs:118:36
     |
 118 |     sql!(Table.filter(i32_field >= 3.141592));
-    |                                    ^^^^^^^^ expected i32, found floating-point variable
+    |                                    ^^^^^^^^ expected i32, found floating-point number
     |
     = note: expected type `i32`
                found type `{float}`
@@ -99,19 +99,19 @@ error[E0609]: no field `fild1` on type `Table`
    --> $DIR/select.rs:124:45
     |
 124 |     sql!(Table.filter(i32_field >= 42).sort(fild1));
-    |                                             ^^^^^ did you mean `field1`?
+    |                                             ^^^^^ help: a field with a similar name exists: `field1`
 
 error[E0609]: no field `fild1` on type `Table`
    --> $DIR/select.rs:128:46
     |
 128 |     sql!(Table.filter(i32_field >= 42).sort(-fild1));
-    |                                              ^^^^^ did you mean `field1`?
+    |                                              ^^^^^ help: a field with a similar name exists: `field1`
 
 error[E0609]: no field `i32_fiel` on type `Table`
    --> $DIR/select.rs:132:23
     |
 132 |     sql!(Table.filter(i32_fiel >= 42));
-    |                       ^^^^^^^^ did you mean `i32_field`?
+    |                       ^^^^^^^^ help: a field with a similar name exists: `i32_field`
 
 error[E0308]: mismatched types
    --> $DIR/select.rs:136:36
@@ -137,7 +137,9 @@ error[E0609]: no field `field` on type `Table`
    --> $DIR/select.rs:151:27
     |
 151 |     sql!(Table.all().join(field));
-    |                           ^^^^^ did you mean `field1`?
+    |                           ^^^^^ help: a field with a similar name exists: `field1`
 
 error: aborting due to 20 previous errors
 
+Some errors occurred: E0308, E0609.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/select_expr.rs
+++ b/tests/testcrate/tests/ui/select_expr.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for a `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/select_expr.stderr
+++ b/tests/testcrate/tests/ui/select_expr.stderr
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
 70 |     sql!(Table.filter(i32_field > value && field1 == value1));
    |                                                      ^^^^^^
    |                                                      |
-   |                                                      expected struct `std::string::String`, found integral variable
+   |                                                      expected struct `std::string::String`, found integer
    |                                                      help: try using a conversion method: `value1.to_string()`
    |
    = note: expected type `std::string::String`
@@ -47,3 +47,4 @@ error[E0308]: mismatched types
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/select_fk.rs
+++ b/tests/testcrate/tests/ui/select_fk.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/testcrate/tests/ui/select_fk.rs
+++ b/tests/testcrate/tests/ui/select_fk.rs
@@ -23,7 +23,6 @@
 
 #![feature(proc_macro_hygiene)]
 
-//extern crate postgres;
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;

--- a/tests/testcrate/tests/ui/select_fk.rs
+++ b/tests/testcrate/tests/ui/select_fk.rs
@@ -27,10 +27,14 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
-use tql::{ForeignKey, PrimaryKey};
+
+#[macro_use] 
+mod connection;
 backend_extern_crate!();
-use connection::{Connection, get_connection};    
+
+use tql::{ForeignKey, PrimaryKey};
+use connection::{Connection, get_connection}; 
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/select_fk.rs
+++ b/tests/testcrate/tests/ui/select_fk.rs
@@ -23,24 +23,24 @@
 
 #![feature(proc_macro_hygiene)]
 
-extern crate postgres;
+//extern crate postgres;
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
 use tql::{ForeignKey, PrimaryKey};
-
+backend_extern_crate!();
+use connection::{Connection, get_connection};    
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
     related: ForeignKey<RelatedTable>,
 }
-
 #[derive(SqlTable)]
 struct RelatedTable {
     field1: String,
 }
-
 fn main() {
+    let connection = get_connection();
     sql!(Table.all().join(related));
 }

--- a/tests/testcrate/tests/ui/select_fk.stderr
+++ b/tests/testcrate/tests/ui/select_fk.stderr
@@ -1,16 +1,16 @@
 warning: No primary key found
-  --> $DIR/select_fk.rs:44:8
+  --> $DIR/select_fk.rs:43:8
    |
-44 | struct RelatedTable {
+43 | struct RelatedTable {
    |        ^^^^^^^^^^^^
 
 error: No primary key found for table RelatedTable which is needed for a join
-  --> $DIR/select_fk.rs:44:8
+  --> $DIR/select_fk.rs:43:8
    |
-44 | struct RelatedTable {
+43 | struct RelatedTable {
    |        ^^^^^^^^^^^^
 ...
-49 |     sql!(Table.all().join(related));
+48 |     sql!(Table.all().join(related));
    |                           ------- in this macro invocation
 
 error: aborting due to previous error

--- a/tests/testcrate/tests/ui/select_fk.stderr
+++ b/tests/testcrate/tests/ui/select_fk.stderr
@@ -1,16 +1,16 @@
 warning: No primary key found
-  --> $DIR/select_fk.rs:40:8
+  --> $DIR/select_fk.rs:44:8
    |
-40 | struct RelatedTable {
+44 | struct RelatedTable {
    |        ^^^^^^^^^^^^
 
 error: No primary key found for table RelatedTable which is needed for a join
-  --> $DIR/select_fk.rs:40:8
+  --> $DIR/select_fk.rs:44:8
    |
-40 | struct RelatedTable {
+44 | struct RelatedTable {
    |        ^^^^^^^^^^^^
 ...
-45 |     sql!(Table.all().join(related));
+49 |     sql!(Table.all().join(related));
    |                           ------- in this macro invocation
 
 error: aborting due to previous error

--- a/tests/testcrate/tests/ui/select_gen.rs
+++ b/tests/testcrate/tests/ui/select_gen.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the generated code for a `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/select_gen.stderr
+++ b/tests/testcrate/tests/ui/select_gen.stderr
@@ -12,3 +12,4 @@ error[E0425]: cannot find value `value2` in this scope
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/testcrate/tests/ui/select_join.rs
+++ b/tests/testcrate/tests/ui/select_join.rs
@@ -23,15 +23,18 @@
 
 #![feature(proc_macro_hygiene)]
 
-
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use connection::{Connection, get_connection};
 use tql::PrimaryKey;
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,

--- a/tests/testcrate/tests/ui/select_join.rs
+++ b/tests/testcrate/tests/ui/select_join.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/testcrate/tests/ui/select_join.rs
+++ b/tests/testcrate/tests/ui/select_join.rs
@@ -47,10 +47,6 @@ struct RelatedTable {
     id: PrimaryKey,
 }
 
-//fn get_connection() -> Connection {
-//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-//}
-
 fn main() {
     let connection = get_connection();
 

--- a/tests/testcrate/tests/ui/select_join.rs
+++ b/tests/testcrate/tests/ui/select_join.rs
@@ -23,15 +23,15 @@
 
 #![feature(proc_macro_hygiene)]
 
-extern crate postgres;
+
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
-use postgres::{Connection, TlsMode};
+#[macro_use] mod connection;
+use connection::{Connection, get_connection};
 use tql::PrimaryKey;
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
@@ -44,9 +44,9 @@ struct RelatedTable {
     id: PrimaryKey,
 }
 
-fn get_connection() -> Connection {
-    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-}
+//fn get_connection() -> Connection {
+//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
+//}
 
 fn main() {
     let connection = get_connection();

--- a/tests/testcrate/tests/ui/select_join.stderr
+++ b/tests/testcrate/tests/ui/select_join.stderr
@@ -20,5 +20,24 @@ expected type `ForeignKey<_>`
 54 |     sql!(Table.all().join(field1, i32_field));
    |                                   --------- in this macro invocation
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/select_join.rs:54:27
+   |
+54 |     sql!(Table.all().join(field1, i32_field));
+   |                           ^^^^^^ expected enum `std::option::Option`, found struct `std::string::String`
+   |
+   = note: expected type `std::option::Option<_>`
+              found type `std::string::String`
 
+error[E0308]: mismatched types
+  --> $DIR/select_join.rs:54:35
+   |
+54 |     sql!(Table.all().join(field1, i32_field));
+   |                                   ^^^^^^^^^ expected enum `std::option::Option`, found i32
+   |
+   = note: expected type `std::option::Option<_>`
+              found type `i32`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/select_join.stderr
+++ b/tests/testcrate/tests/ui/select_join.stderr
@@ -1,38 +1,38 @@
 error: mismatched types
 expected type `ForeignKey<_>`
    found type `String`
-  --> $DIR/select_join.rs:38:5
+  --> $DIR/select_join.rs:41:5
    |
-38 |     field1: String,
+41 |     field1: String,
    |     ^^^^^^^^^^^^^^
 ...
-54 |     sql!(Table.all().join(field1, i32_field));
+57 |     sql!(Table.all().join(field1, i32_field));
    |                           ------ in this macro invocation
 
 error: mismatched types
 expected type `ForeignKey<_>`
    found type `i32`
-  --> $DIR/select_join.rs:39:5
+  --> $DIR/select_join.rs:42:5
    |
-39 |     i32_field: i32,
+42 |     i32_field: i32,
    |     ^^^^^^^^^^^^^^
 ...
-54 |     sql!(Table.all().join(field1, i32_field));
+57 |     sql!(Table.all().join(field1, i32_field));
    |                                   --------- in this macro invocation
 
 error[E0308]: mismatched types
-  --> $DIR/select_join.rs:54:27
+  --> $DIR/select_join.rs:57:27
    |
-54 |     sql!(Table.all().join(field1, i32_field));
+57 |     sql!(Table.all().join(field1, i32_field));
    |                           ^^^^^^ expected enum `std::option::Option`, found struct `std::string::String`
    |
    = note: expected type `std::option::Option<_>`
               found type `std::string::String`
 
 error[E0308]: mismatched types
-  --> $DIR/select_join.rs:54:35
+  --> $DIR/select_join.rs:57:35
    |
-54 |     sql!(Table.all().join(field1, i32_field));
+57 |     sql!(Table.all().join(field1, i32_field));
    |                                   ^^^^^^^^^ expected enum `std::option::Option`, found i32
    |
    = note: expected type `std::option::Option<_>`

--- a/tests/testcrate/tests/ui/select_join.stderr
+++ b/tests/testcrate/tests/ui/select_join.stderr
@@ -6,7 +6,7 @@ expected type `ForeignKey<_>`
 41 |     field1: String,
    |     ^^^^^^^^^^^^^^
 ...
-57 |     sql!(Table.all().join(field1, i32_field));
+53 |     sql!(Table.all().join(field1, i32_field));
    |                           ------ in this macro invocation
 
 error: mismatched types
@@ -17,22 +17,22 @@ expected type `ForeignKey<_>`
 42 |     i32_field: i32,
    |     ^^^^^^^^^^^^^^
 ...
-57 |     sql!(Table.all().join(field1, i32_field));
+53 |     sql!(Table.all().join(field1, i32_field));
    |                                   --------- in this macro invocation
 
 error[E0308]: mismatched types
-  --> $DIR/select_join.rs:57:27
+  --> $DIR/select_join.rs:53:27
    |
-57 |     sql!(Table.all().join(field1, i32_field));
+53 |     sql!(Table.all().join(field1, i32_field));
    |                           ^^^^^^ expected enum `std::option::Option`, found struct `std::string::String`
    |
    = note: expected type `std::option::Option<_>`
               found type `std::string::String`
 
 error[E0308]: mismatched types
-  --> $DIR/select_join.rs:57:35
+  --> $DIR/select_join.rs:53:35
    |
-57 |     sql!(Table.all().join(field1, i32_field));
+53 |     sql!(Table.all().join(field1, i32_field));
    |                                   ^^^^^^^^^ expected enum `std::option::Option`, found i32
    |
    = note: expected type `std::option::Option<_>`

--- a/tests/testcrate/tests/ui/select_macro.rs
+++ b/tests/testcrate/tests/ui/select_macro.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/select_macro.stderr
+++ b/tests/testcrate/tests/ui/select_macro.stderr
@@ -8,7 +8,8 @@ error[E0412]: cannot find type `Tble` in this scope
   --> $DIR/select_macro.rs:49:10
    |
 49 |     sql!(Tble.filter(field1 == "value"));
-   |          ^^^^ did you mean `Table`?
+   |          ^^^^ help: a struct with a similar name exists: `Table`
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/testcrate/tests/ui/select_syntax.rs
+++ b/tests/testcrate/tests/ui/select_syntax.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the methods related to `Query::Select`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate postgres;
 extern crate tql;

--- a/tests/testcrate/tests/ui/select_syntax.rs
+++ b/tests/testcrate/tests/ui/select_syntax.rs
@@ -23,15 +23,15 @@
 
 #![feature(proc_macro_hygiene)]
 
-extern crate postgres;
+
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
-use postgres::{Connection, TlsMode};
+#[macro_use] mod connection;
+use connection::{Connection, get_connection};
 use tql::PrimaryKey;
 use tql_macros::sql;
-
+backend_extern_crate!();
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
@@ -39,9 +39,9 @@ struct Table {
     i32_field: i32,
 }
 
-fn get_connection() -> Connection {
-    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-}
+//fn get_connection() -> Connection {
+//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
+//}
 
 fn main() {
     let connection = get_connection();

--- a/tests/testcrate/tests/ui/select_syntax.rs
+++ b/tests/testcrate/tests/ui/select_syntax.rs
@@ -27,21 +27,21 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+
+#[macro_use] 
+mod connection;
+backend_extern_crate!();
+
 use connection::{Connection, get_connection};
 use tql::PrimaryKey;
 use tql_macros::sql;
-backend_extern_crate!();
+
 #[derive(SqlTable)]
 struct Table {
     id: PrimaryKey,
     field1: String,
     i32_field: i32,
 }
-
-//fn get_connection() -> Connection {
-//    Connection::connect("postgres://test:test@localhost/database", TlsMode::None).unwrap()
-//}
 
 fn main() {
     let connection = get_connection();

--- a/tests/testcrate/tests/ui/sql_table.rs
+++ b/tests/testcrate/tests/ui/sql_table.rs
@@ -1,4 +1,4 @@
-        /*
+/*
  * Copyright (c) 2017-2018 Boucher, Antoni <bouanto@zoho.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +21,7 @@
 
 //! Tests of the `#[SqlTable]` attribute.
 
-#![feature(proc_macro_hygiene)] // FIXME: bad span for field nested_options in stderr (should be on Option<String>, not just Option).
+#![feature(proc_macro_hygiene)] 
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/sql_table.rs
+++ b/tests/testcrate/tests/ui/sql_table.rs
@@ -1,4 +1,4 @@
-/*
+        /*
  * Copyright (c) 2017-2018 Boucher, Antoni <bouanto@zoho.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,14 +22,14 @@
 //! Tests of the `#[SqlTable]` attribute.
 
 #![feature(proc_macro_hygiene)] // FIXME: bad span for field nested_options in stderr (should be on Option<String>, not just Option).
-
+extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-
+#[macro_use] mod connection;
+backend_extern_crate!();
 struct Connection {
     value: String,
 }
-
 #[derive(SqlTable)]
 struct Table<'a> {
     //~^ WARNING No primary key found
@@ -53,4 +53,8 @@ struct Table<'a> {
     //~^ ERROR use of unsupported type name `Vec`
     vector_i32: Vec<i32>,
     //~^ ERROR use of unsupported type name `Vec<i32>`
+}
+
+fn main() {
+    
 }

--- a/tests/testcrate/tests/ui/sql_table.rs
+++ b/tests/testcrate/tests/ui/sql_table.rs
@@ -25,7 +25,7 @@
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection;
+#[macro_use] mod connection; use tql::{DateTime,ForeignKey};
 backend_extern_crate!();
 struct Connection {
     value: String,

--- a/tests/testcrate/tests/ui/sql_table.rs
+++ b/tests/testcrate/tests/ui/sql_table.rs
@@ -22,11 +22,17 @@
 //! Tests of the `#[SqlTable]` attribute.
 
 #![feature(proc_macro_hygiene)] // FIXME: bad span for field nested_options in stderr (should be on Option<String>, not just Option).
+
 extern crate tql;
 #[macro_use]
 extern crate tql_macros;
-#[macro_use] mod connection; use tql::{DateTime,ForeignKey};
+
+#[macro_use] 
+mod connection; 
 backend_extern_crate!();
+
+use tql::{DateTime,ForeignKey};
+
 struct Connection {
     value: String,
 }

--- a/tests/testcrate/tests/ui/sql_table.rs
+++ b/tests/testcrate/tests/ui/sql_table.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the `#[SqlTable]` attribute.
 
-#![feature(proc_macro)] // FIXME: bad span for field nested_options in stderr (should be on Option<String>, not just Option).
+#![feature(proc_macro_hygiene)] // FIXME: bad span for field nested_options in stderr (should be on Option<String>, not just Option).
 
 #[macro_use]
 extern crate tql_macros;

--- a/tests/testcrate/tests/ui/sql_table.stderr
+++ b/tests/testcrate/tests/ui/sql_table.stderr
@@ -1,97 +1,97 @@
 warning: No primary key found
-  --> $DIR/sql_table.rs:34:8
+  --> $DIR/sql_table.rs:40:8
    |
-34 | struct Table<'a> {
+40 | struct Table<'a> {
    |        ^^^^^
 
 error: use of unsupported type name `& 'a str`
-  --> $DIR/sql_table.rs:36:13
+  --> $DIR/sql_table.rs:42:13
    |
-36 |     string: &'a str,
+42 |     string: &'a str,
    |             ^^^^^^^
 
 error: use of unsupported type name `Connection`
-  --> $DIR/sql_table.rs:38:17
+  --> $DIR/sql_table.rs:44:17
    |
-38 |     connection: Connection,
+44 |     connection: Connection,
    |                 ^^^^^^^^^^
 
 error: use of unsupported type name `Connection`
-  --> $DIR/sql_table.rs:40:25
+  --> $DIR/sql_table.rs:46:25
    |
-40 |     connection2: Option<Connection>,
+46 |     connection2: Option<Connection>,
    |                         ^^^^^^^^^^
 
 error: use of unsupported type name `Option<String>`
-  --> $DIR/sql_table.rs:42:28
+  --> $DIR/sql_table.rs:48:28
    |
-42 |     nested_options: Option<Option<String>>,
+48 |     nested_options: Option<Option<String>>,
    |                            ^^^^^^^^^^^^^^^
 
 error: use of unsupported type name `DateTime`
-  --> $DIR/sql_table.rs:44:15
+  --> $DIR/sql_table.rs:50:15
    |
-44 |     datetime: DateTime,
+50 |     datetime: DateTime,
    |               ^^^^^^^^
 
 error: use of unsupported type name `DateTime<i32>`
-  --> $DIR/sql_table.rs:46:19
+  --> $DIR/sql_table.rs:52:19
    |
-46 |     datetime_i32: DateTime<i32>,
+52 |     datetime_i32: DateTime<i32>,
    |                   ^^^^^^^^^^^^^
 
 error: use of unsupported type name `ForeignKey`
-  --> $DIR/sql_table.rs:48:20
+  --> $DIR/sql_table.rs:54:20
    |
-48 |     foreign_value: ForeignKey,
+54 |     foreign_value: ForeignKey,
    |                    ^^^^^^^^^^
 
 error: use of unsupported type name `Option`
-  --> $DIR/sql_table.rs:50:21
+  --> $DIR/sql_table.rs:56:21
    |
-50 |     optional_value: Option,
+56 |     optional_value: Option,
    |                     ^^^^^^
 
 error: use of unsupported type name `Vec`
-  --> $DIR/sql_table.rs:52:13
+  --> $DIR/sql_table.rs:58:13
    |
-52 |     vector: Vec,
+58 |     vector: Vec,
    |             ^^^
 
 error: use of unsupported type name `Vec<i32>`
-  --> $DIR/sql_table.rs:54:17
+  --> $DIR/sql_table.rs:60:17
    |
-54 |     vector_i32: Vec<i32>,
+60 |     vector_i32: Vec<i32>,
    |                 ^^^^^^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/sql_table.rs:34:8
+  --> $DIR/sql_table.rs:40:8
    |
-34 | struct Table<'a> {
+40 | struct Table<'a> {
    |        ^^^^^ expected lifetime parameter
 
 error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/sql_table.rs:46:28
+  --> $DIR/sql_table.rs:52:28
    |
-46 |     datetime_i32: DateTime<i32>,
+52 |     datetime_i32: DateTime<i32>,
    |                            ^^^ unexpected type argument
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/sql_table.rs:48:20
+  --> $DIR/sql_table.rs:54:20
    |
-48 |     foreign_value: ForeignKey,
+54 |     foreign_value: ForeignKey,
    |                    ^^^^^^^^^^ expected 1 type argument
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/sql_table.rs:50:21
+  --> $DIR/sql_table.rs:56:21
    |
-50 |     optional_value: Option,
+56 |     optional_value: Option,
    |                     ^^^^^^ expected 1 type argument
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
-  --> $DIR/sql_table.rs:52:13
+  --> $DIR/sql_table.rs:58:13
    |
-52 |     vector: Vec,
+58 |     vector: Vec,
    |             ^^^ expected 1 type argument
 
 error: aborting due to 15 previous errors

--- a/tests/testcrate/tests/ui/sql_table.stderr
+++ b/tests/testcrate/tests/ui/sql_table.stderr
@@ -64,5 +64,37 @@ error: use of unsupported type name `Vec<i32>`
 54 |     vector_i32: Vec<i32>,
    |                 ^^^^^^^^
 
-error: aborting due to 10 previous errors
+error[E0106]: missing lifetime specifier
+  --> $DIR/sql_table.rs:34:8
+   |
+34 | struct Table<'a> {
+   |        ^^^^^ expected lifetime parameter
 
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/sql_table.rs:46:28
+   |
+46 |     datetime_i32: DateTime<i32>,
+   |                            ^^^ unexpected type argument
+
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/sql_table.rs:48:20
+   |
+48 |     foreign_value: ForeignKey,
+   |                    ^^^^^^^^^^ expected 1 type argument
+
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/sql_table.rs:50:21
+   |
+50 |     optional_value: Option,
+   |                     ^^^^^^ expected 1 type argument
+
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/sql_table.rs:52:13
+   |
+52 |     vector: Vec,
+   |             ^^^ expected 1 type argument
+
+error: aborting due to 15 previous errors
+
+Some errors occurred: E0106, E0107.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/testcrate/tests/ui/sql_table_expr.rs
+++ b/tests/testcrate/tests/ui/sql_table_expr.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for the `#[SqlTable]` attribute.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/sql_table_expr.stderr
+++ b/tests/testcrate/tests/ui/sql_table_expr.stderr
@@ -10,7 +10,9 @@ error[E0277]: the trait bound `Connection: tql::SqlTable` is not satisfied
 44 |     related_field1: ForeignKey<Connection>,
    |                                ^^^^^^^^^^ the trait `tql::SqlTable` is not implemented for `Connection`
    |
-   = note: required by `tql::SqlTable`
+   = help: see issue #48214
+   = help: add #![feature(trivial_bounds)] to the crate attributes to enable
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/testcrate/tests/ui/update.rs
+++ b/tests/testcrate/tests/ui/update.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the update() method.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/update.stderr
+++ b/tests/testcrate/tests/ui/update.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 49 |     let _ = sql!(Table.filter(id == 1).update(field1 = 42, i32_field = value));
    |                                                        ^^
    |                                                        |
-   |                                                        expected struct `std::string::String`, found integral variable
+   |                                                        expected struct `std::string::String`, found integer
    |                                                        help: try using a conversion method: `42.to_string()`
    |
    = note: expected type `std::string::String`
@@ -20,3 +20,5 @@ error[E0609]: no field `value` on type `Table`
 
 error: aborting due to 2 previous errors
 
+Some errors occurred: E0308, E0609.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/testcrate/tests/ui/update_expr.rs
+++ b/tests/testcrate/tests/ui/update_expr.rs
@@ -21,7 +21,7 @@
 
 //! Tests of the type analyzer lint for a `Query::Update`.
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/testcrate/tests/ui/update_expr.stderr
+++ b/tests/testcrate/tests/ui/update_expr.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 50 |     let _ = sql!(Table.filter(id == 1).update(field1 = value, i32_field = value));
    |                                                        ^^^^^
    |                                                        |
-   |                                                        expected struct `std::string::String`, found integral variable
+   |                                                        expected struct `std::string::String`, found integer
    |                                                        help: try using a conversion method: `value.to_string()`
    |
    = note: expected type `std::string::String`
@@ -12,3 +12,4 @@ error[E0308]: mismatched types
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 extern crate tql;
 #[macro_use]

--- a/tests/update_expr.rs
+++ b/tests/update_expr.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(proc_macro)]
+#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/tql_macros/Cargo.toml
+++ b/tql_macros/Cargo.toml
@@ -11,14 +11,14 @@ version = "0.1.0"
 rand = "^0.4.2"
 
 [dependencies.proc-macro2]
-version = "0.3"
+version = "0.4"
 
 [dependencies.quote]
-version = "0.5"
+version = "0.6"
 
 [dependencies.syn]
 features = ["extra-traits", "printing", "full"]
-version = "0.13"
+version = "0.15"
 
 [lib]
 proc-macro = true

--- a/tql_macros/src/analyzer/aggregate.rs
+++ b/tql_macros/src/analyzer/aggregate.rs
@@ -79,7 +79,7 @@ pub fn argument_to_aggregate(arg: &Expression) -> Result<Aggregate> {
             }
         }
 
-        if check_argument_count(&call.args, 1, arg.span(), &mut errors) {
+        if check_argument_count(&call.args, 1, crate::merge_spans_of(arg), &mut errors) {
             if let Expr::Path(ref path) = **call.args.first().expect("first argument").value() {
                 let path_ident = &path.path.segments.first().unwrap().into_value().ident;
                 aggregate.field = Some(path_ident.clone());

--- a/tql_macros/src/analyzer/aggregate.rs
+++ b/tql_macros/src/analyzer/aggregate.rs
@@ -115,7 +115,7 @@ pub fn argument_to_aggregate(arg: &Expression) -> Result<Aggregate> {
 /// Convert an `Expression` to a group `Ident`.
 pub fn argument_to_group(arg: &Expression) -> Result<Ident> {
     let mut errors = vec![];
-    let mut group = Ident::new("dummy_ident", Span::call_site());
+    let mut group = Ident::new("__tql_dummy_ident", Span::call_site());
 
     if let Some(identifier) = path_expr_to_identifier(arg, &mut errors) {
         group = identifier;

--- a/tql_macros/src/analyzer/aggregate.rs
+++ b/tql_macros/src/analyzer/aggregate.rs
@@ -79,7 +79,7 @@ pub fn argument_to_aggregate(arg: &Expression) -> Result<Aggregate> {
             }
         }
 
-        if check_argument_count(&call.args, 1, crate::merge_spans_of(arg), &mut errors) {
+        if check_argument_count(&call.args, 1, arg.span(), &mut errors) {
             if let Expr::Path(ref path) = **call.args.first().expect("first argument").value() {
                 let path_ident = &path.path.segments.first().unwrap().into_value().ident;
                 aggregate.field = Some(path_ident.clone());

--- a/tql_macros/src/analyzer/aggregate.rs
+++ b/tql_macros/src/analyzer/aggregate.rs
@@ -166,8 +166,7 @@ fn binary_expression_to_aggregate_filter_expression(expr1: &Expression, op: &Bin
 
 /// Check that an aggregate field exists.
 fn check_aggregate_field<'a>(identifier: &str, aggregates: &'a [Aggregate], position: Span, errors: &mut Vec<Error>) -> Option<&'a Aggregate> {
-    let matching = Some(identifier.to_string());
-    let result = aggregates.iter().find(|aggr| aggr.result_name.as_ref().map(|name| name.to_string()) == matching);
+    let result = aggregates.iter().find(|aggr| aggr.result_name.as_ref().map_or(false, |name| name == identifier));
     if let None = result {
         errors.push(Error::new(
             &format!("no aggregate field named `{}` found", identifier), // TODO: improve this message.

--- a/tql_macros/src/analyzer/aggregate.rs
+++ b/tql_macros/src/analyzer/aggregate.rs
@@ -81,11 +81,11 @@ pub fn argument_to_aggregate(arg: &Expression) -> Result<Aggregate> {
 
         if check_argument_count(&call.args, 1, arg.span(), &mut errors) {
             if let Expr::Path(ref path) = **call.args.first().expect("first argument").value() {
-                let path_ident = path.path.segments.first().unwrap().into_value().ident;
-                aggregate.field = Some(path_ident);
+                let path_ident = &path.path.segments.first().unwrap().into_value().ident;
+                aggregate.field = Some(path_ident.clone());
 
                 if aggregate.result_name.is_none() {
-                    let result_name = aggregate.field.expect("Aggregate identifier").to_string() + "_" +
+                    let result_name = aggregate.field.clone().expect("Aggregate identifier").to_string() + "_" +
                         &aggregate.sql_function.to_lowercase();
                     let mut ident = new_ident(&result_name);
                     // NOTE: violate the hygiene by assigning a known context to this new
@@ -115,7 +115,7 @@ pub fn argument_to_aggregate(arg: &Expression) -> Result<Aggregate> {
 /// Convert an `Expression` to a group `Ident`.
 pub fn argument_to_group(arg: &Expression) -> Result<Ident> {
     let mut errors = vec![];
-    let mut group = Ident::from("dummy_ident");
+    let mut group = Ident::new("dummy_ident", Span::call_site());
 
     if let Some(identifier) = path_expr_to_identifier(arg, &mut errors) {
         group = identifier;
@@ -166,7 +166,8 @@ fn binary_expression_to_aggregate_filter_expression(expr1: &Expression, op: &Bin
 
 /// Check that an aggregate field exists.
 fn check_aggregate_field<'a>(identifier: &str, aggregates: &'a [Aggregate], position: Span, errors: &mut Vec<Error>) -> Option<&'a Aggregate> {
-    let result = aggregates.iter().find(|aggr| aggr.result_name.as_ref().map(|name| name.as_ref()) == Some(identifier));
+    let matching = Some(identifier.to_string());
+    let result = aggregates.iter().find(|aggr| aggr.result_name.as_ref().map(|name| name.to_string()) == matching);
     if let None = result {
         errors.push(Error::new(
             &format!("no aggregate field named `{}` found", identifier), // TODO: improve this message.
@@ -187,7 +188,7 @@ pub fn expression_to_aggregate_filter_expression(arg: &Expression, aggregates: &
                 binary_expression_to_aggregate_filter_expression(&bin.left, &bin.op, &bin.right, aggregates)?
             },
             Expr::Path(ref path) => {
-                let segment_ident = path.path.segments.first().unwrap().into_value().ident;
+                let segment_ident = &path.path.segments.first().unwrap().into_value().ident;
                 let identifier = segment_ident.to_string();
                 let aggregate = check_aggregate_field(&identifier, aggregates, segment_ident.span(), &mut errors);
                 if let Some(aggregate) = aggregate {

--- a/tql_macros/src/analyzer/assignment.rs
+++ b/tql_macros/src/analyzer/assignment.rs
@@ -81,12 +81,12 @@ pub fn argument_to_assignment(arg: &Expression) -> Result<Assignment> {
 /// Convert a `BinOp` to an SQL `AssignmentOperator`.
 fn binop_to_assignment_operator(binop: &BinOp) -> (AssignmentOperator, Span) {
     match *binop {
-        BinOp::AddEq(span) => (AssignmentOperator::Add, span.0[0]),
-        BinOp::SubEq(span) => (AssignmentOperator::Sub, span.0[0]),
-        BinOp::MulEq(span) => (AssignmentOperator::Mul, span.0[0]),
-        BinOp::DivEq(span) => (AssignmentOperator::Divide, span.0[0]),
-        BinOp::RemEq(span) => (AssignmentOperator::Modulo, span.0[0]),
-        BinOp::Eq(span) => (AssignmentOperator::Equal, span.0[0]),
+        BinOp::AddEq(span) => (AssignmentOperator::Add, span.spans[0]),
+        BinOp::SubEq(span) => (AssignmentOperator::Sub, span.spans[0]),
+        BinOp::MulEq(span) => (AssignmentOperator::Mul, span.spans[0]),
+        BinOp::DivEq(span) => (AssignmentOperator::Divide, span.spans[0]),
+        BinOp::RemEq(span) => (AssignmentOperator::Modulo, span.spans[0]),
+        BinOp::Eq(span) => (AssignmentOperator::Equal, span.spans[0]),
         BinOp::Add(_) | BinOp::Sub(_) | BinOp::Mul(_) | BinOp::Div(_) | BinOp::Rem(_) | BinOp::And(_) |
             BinOp::Or(_) | BinOp::BitXor(_) | BinOp::BitXorEq(_) | BinOp::BitAnd(_) | BinOp::BitAndEq(_) |
             BinOp::BitOr(_) | BinOp::BitOrEq(_) | BinOp::Shl(_) | BinOp::ShlEq(_) | BinOp::Shr(_) | BinOp::ShrEq(_) |

--- a/tql_macros/src/analyzer/filter.rs
+++ b/tql_macros/src/analyzer/filter.rs
@@ -147,13 +147,13 @@ pub fn expression_to_filter_expression(arg: &Expression, table_name: &str) -> Re
             },
             Expr::MethodCall(ref call) => {
                 FilterExpression::FilterValue(WithSpan {
-                    node: method_call_expression_to_filter_expression(call.method, &call.receiver, &call.args,
+                    node: method_call_expression_to_filter_expression(call.method.clone(), &call.receiver, &call.args,
                                                                       call.span(), &mut errors),
                     span: arg.span(),
                 })
             },
             Expr::Path(ref path) => {
-                let identifier = path.path.segments.first().unwrap().into_value().ident;
+                let identifier = path.path.segments.first().unwrap().into_value().ident.clone();
                 FilterExpression::FilterValue(WithSpan {
                     node: FilterValue::Identifier(table_name.to_string(), identifier),
                     span: arg.span(),
@@ -217,7 +217,7 @@ fn method_call_expression_to_filter_expression(identifier: Ident, expr: &Express
 /// Convert a method call where the object is an identifier to a filter expression.
 fn path_method_call_to_filter(path: &Path, identifier: Ident, args: &Punctuated<Expr, Comma>, position: Span) -> FilterValue
 {
-    let object_name = path.segments.first().unwrap().into_value().ident;
+    let object_name = path.segments.first().unwrap().into_value().ident.clone();
     let arguments: Vec<Expression> = args.iter()
         .cloned()
         .collect();

--- a/tql_macros/src/analyzer/filter.rs
+++ b/tql_macros/src/analyzer/filter.rs
@@ -146,10 +146,9 @@ pub fn expression_to_filter_expression(arg: &Expression, table_name: &str) -> Re
                 binary_expression_to_filter_expression(&bin.left, &bin.op, &bin.right, table_name)?
             },
             Expr::MethodCall(ref call) => {
-                let call_span = crate::merge_spans_of(call);
                 FilterExpression::FilterValue(WithSpan {
                     node: method_call_expression_to_filter_expression(call.method.clone(), &call.receiver, &call.args,
-                                                                      call_span, &mut errors),
+                                                                      call.span(), &mut errors),
                     span: arg.span(),
                 })
             },

--- a/tql_macros/src/analyzer/filter.rs
+++ b/tql_macros/src/analyzer/filter.rs
@@ -146,9 +146,10 @@ pub fn expression_to_filter_expression(arg: &Expression, table_name: &str) -> Re
                 binary_expression_to_filter_expression(&bin.left, &bin.op, &bin.right, table_name)?
             },
             Expr::MethodCall(ref call) => {
+                let call_span = crate::merge_spans_of(call);
                 FilterExpression::FilterValue(WithSpan {
                     node: method_call_expression_to_filter_expression(call.method.clone(), &call.receiver, &call.args,
-                                                                      call.span(), &mut errors),
+                                                                      call_span, &mut errors),
                     span: arg.span(),
                 })
             },

--- a/tql_macros/src/analyzer/method.rs
+++ b/tql_macros/src/analyzer/method.rs
@@ -29,10 +29,10 @@ pub fn analyze_methods(query: &Query) -> Result<()> {
     let calls = get_method_calls(query);
     let mut errors = vec![];
     for (call, _) in calls {
-        let name = call.method_name.as_ref();
-        if let Some(method) = methods.get(name) {
+        let name = call.method_name.to_string();
+        if let Some(method) = methods.get(&name) {
             if method.template.is_none() {
-                errors.push(Error::new(&format!("The method {} is not available on this backend", name),
+                errors.push(Error::new(&format!("The method {} is not available on this backend", &name),
                     call.method_name.span()))
             }
         }

--- a/tql_macros/src/analyzer/sort.rs
+++ b/tql_macros/src/analyzer/sort.rs
@@ -47,7 +47,7 @@ pub fn argument_to_order(arg: &Expression) -> Result<Order> {
                 Order::Descending(ident)
             }
             Expr::Path(ref path) => {
-                let identifier = path.path.segments.first().unwrap().into_value().ident;
+                let identifier = path.path.segments.first().unwrap().into_value().ident.clone();
                 Order::Ascending(identifier)
             }
             _ => {

--- a/tql_macros/src/ast.rs
+++ b/tql_macros/src/ast.rs
@@ -24,7 +24,7 @@
 use std::fmt::{Display, Error, Formatter};
 
 use proc_macro2::{Span, TokenStream};
-use quote::{Tokens, ToTokens};
+use quote::ToTokens;
 use syn::{Expr, Ident};
 
 pub type Expression = Expr;
@@ -288,7 +288,7 @@ pub enum QueryType {
 #[derive(Debug)]
 pub struct TypedField {
     pub identifier: String,
-    pub typ: Tokens,
+    pub typ: TokenStream,
 }
 
 /// Get the query type.
@@ -326,6 +326,6 @@ pub struct WithSpan<T> {
 
 /// Get the position of the first token of the expression.
 pub fn first_token_span(expr: &Expr) -> Span {
-    let tokens: TokenStream = expr.into_tokens().into();
+    let tokens: TokenStream = expr.into_token_stream().into();
     tokens.into_iter().next().expect("first token of method call expression").span()
 }

--- a/tql_macros/src/attribute.rs
+++ b/tql_macros/src/attribute.rs
@@ -50,14 +50,14 @@ pub fn field_ty_to_type(ty: &syn::Type) -> WithSpan<Type> {
             let _ = write!(type_string, "{}", quote! { #ty });
             Type::UnsupportedType(type_string)
         };
-    let mut position = ty.span();
+    let mut position = crate::merge_spans_of(&ty);
     if let syn::Type::Path(TypePath { ref path, .. }) =  *ty {
         if path.segments.first().expect("first segment in path").value().ident.to_string() == "Option" {
             if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { ref args, .. }) = path.segments.first().expect("first segment in path").value().arguments {
                 // TODO: use unwrap().
                 let element = args.first().expect("first arg");
                 let typ = element.value();
-                position = typ.span();
+                position = crate::merge_spans_of(&typ);
             }
         }
     }

--- a/tql_macros/src/attribute.rs
+++ b/tql_macros/src/attribute.rs
@@ -71,10 +71,10 @@ pub fn field_ty_to_type(ty: &syn::Type) -> WithSpan<Type> {
 pub fn fields_vec_to_hashmap(fields: &[Field]) -> SqlFields {
     let mut sql_fields = BTreeMap::new();
     for field in fields {
-        if let Some(ident) = field.ident {
-            if !sql_fields.contains_key(&ident) {
+        if let Some(ref ident) = &field.ident {
+            if !sql_fields.contains_key(ident) {
                 let ty = field_ty_to_type(&field.ty);
-                sql_fields.insert(ident, BothTypes {
+                sql_fields.insert(ident.clone(), BothTypes {
                     syn_type: field.ty.clone(),
                     ty,
                 });

--- a/tql_macros/src/attribute.rs
+++ b/tql_macros/src/attribute.rs
@@ -50,14 +50,14 @@ pub fn field_ty_to_type(ty: &syn::Type) -> WithSpan<Type> {
             let _ = write!(type_string, "{}", quote! { #ty });
             Type::UnsupportedType(type_string)
         };
-    let mut position = crate::merge_spans_of(&ty);
+    let mut position = ty.span();
     if let syn::Type::Path(TypePath { ref path, .. }) =  *ty {
         if path.segments.first().expect("first segment in path").value().ident.to_string() == "Option" {
             if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { ref args, .. }) = path.segments.first().expect("first segment in path").value().arguments {
                 // TODO: use unwrap().
                 let element = args.first().expect("first arg");
                 let typ = element.value();
-                position = crate::merge_spans_of(&typ);
+                position = typ.span();
             }
         }
     }

--- a/tql_macros/src/error.rs
+++ b/tql_macros/src/error.rs
@@ -28,7 +28,9 @@ use std::result;
 
 #[cfg(feature = "unstable")]
 use proc_macro::{Diagnostic, Level};
-use proc_macro2::{Span,TokenStream};
+#[cfg(not(feature="unstable"))]
+use proc_macro2::TokenStream;
+use proc_macro2::Span;
 
 /// `Error` is a type that represents an error with its position.
 #[derive(Debug)]

--- a/tql_macros/src/error.rs
+++ b/tql_macros/src/error.rs
@@ -28,9 +28,7 @@ use std::result;
 
 #[cfg(feature = "unstable")]
 use proc_macro::{Diagnostic, Level};
-use proc_macro2::Span;
-#[cfg(not(feature = "unstable"))]
-use quote::Tokens;
+use proc_macro2::{Span,TokenStream};
 
 /// `Error` is a type that represents an error with its position.
 #[derive(Debug)]
@@ -193,7 +191,7 @@ pub fn res<T>(result: T, errors: Vec<Error>) -> Result<T> {
 }
 
 #[cfg(not(feature = "unstable"))]
-pub fn compiler_error(msg: &Error) -> Tokens {
+pub fn compiler_error(msg: &Error) -> TokenStream {
     let msg = msg.to_string();
     quote! {
         compile_error!(#msg);

--- a/tql_macros/src/gen/dummy.rs
+++ b/tql_macros/src/gen/dummy.rs
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-use quote::Tokens;
+use proc_macro2::TokenStream;
 use syn::{Expr, Ident};
 
 use super::BackendGen;
@@ -33,16 +33,16 @@ pub fn create_backend() -> DummyBackend {
 }
 
 impl BackendGen for DummyBackend {
-    fn convert_index(&self, _index: usize) -> Tokens {
+    fn convert_index(&self, _index: usize) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 
-    fn delta_type(&self) -> Tokens {
+    fn delta_type(&self) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 
-    fn gen_query_expr(&self, _connection_expr: Tokens, _args: &SqlQueryWithArgs, _args_expr: Tokens, _struct_expr: Tokens,
-                      _aggregate_struct: Tokens, _aggregate_expr: Tokens) -> Tokens
+    fn gen_query_expr(&self, _connection_expr: TokenStream, _args: &SqlQueryWithArgs, _args_expr: TokenStream, _struct_expr: TokenStream,
+                      _aggregate_struct: TokenStream, _aggregate_expr: TokenStream) -> TokenStream
     {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
@@ -51,15 +51,15 @@ impl BackendGen for DummyBackend {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 
-    fn row_type_ident(&self, _table_ident: &Ident) -> Tokens {
+    fn row_type_ident(&self, _table_ident: &Ident) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 
-    fn to_sql(&self, _primary_key_ident: &Ident) -> Tokens {
+    fn to_sql(&self, _primary_key_ident: &Ident) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 
-    fn to_sql_impl(&self, _table_ident: &Ident, _to_sql_code: Tokens) -> Tokens {
+    fn to_sql_impl(&self, _table_ident: &Ident, _to_sql_code: TokenStream) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 }

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -28,7 +28,7 @@ mod sqlite;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::Tokens;
+use proc_macro2::TokenStream as Tokens; // todo: remove
 use rand::{self, Rng};
 use syn::{
     self,
@@ -106,9 +106,9 @@ pub fn table_methods(item_struct: &ItemStruct) -> Tokens {
         let field_count = backend.int_literal(field_count);
 
         let field_idents = named.iter()
-            .map(|field| field.ident.expect("field has name"));
+            .map(|field| field.ident.clone().expect("field has name"));
         let field_idents2 = named.iter()
-            .map(|field| field.ident.expect("field has name"));
+            .map(|field| field.ident.clone().expect("field has name"));
 
         let trait_ident = quote_spanned! { table_ident.span() =>
             ::tql::SqlTable
@@ -182,11 +182,11 @@ fn create_debug_impl(item_struct: &ItemStruct) -> Tokens {
     let table_name = table_ident.to_string();
     if let Fields::Named(FieldsNamed { ref named , .. }) = item_struct.fields {
         let field_idents = named.iter()
-            .map(|field| field.ident.expect("field has name"));
+            .map(|field| field.ident.clone().expect("field has name"));
         let field_names = field_idents
             .map(|ident| ident.to_string());
         let field_idents = named.iter()
-            .map(|field| field.ident.expect("field has name"));
+            .map(|field| field.ident.clone().expect("field has name"));
         let std_ident = quote_spanned! { table_ident.span() =>
             ::std
         };
@@ -305,7 +305,7 @@ pub fn get_struct_fields(item_struct: &ItemStruct) -> (Result<SqlFields>, Option
         };
     let mut primary_key_count = 0;
     for field in &fields {
-        if let Some(field_ident) = field.ident {
+        if let Some(ref field_ident) = field.ident {
             #[cfg(feature = "unstable")]
             let field_type = &field.ty;
             let field_name = field_ident.to_string();
@@ -384,7 +384,7 @@ fn field_list_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) -> To
         })
         .map(|field| {
             format!("{table}.{column}",
-                    column = field.ident.expect("field has name"),
+                    column = field.ident.clone().expect("field has name"),
                     table = table_ident
                    )
         })
@@ -404,7 +404,7 @@ fn create_query_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) -> 
     let mut fields_to_create = vec![];
     for field in named {
         fields_to_create.push(TypedField {
-            identifier: field.ident.expect("field ident").to_string(),
+            identifier: field.ident.clone().expect("field ident").to_string(),
             typ: type_to_sql(&field_ty_to_type(&field.ty).node),
         });
     }
@@ -427,7 +427,7 @@ fn related_pks_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) -> T
     let mut related_pk_macro_names = vec![];
     for field in named {
         let typ = token_to_string(&field.ty);
-        if let Some(ident) = field.ident {
+        if let Some(ref ident) = field.ident {
             if typ.starts_with("ForeignKey") {
                 if let syn::Type::Path(ref path) = field.ty {
                     let element = path.path.segments.first().expect("first segment of path");
@@ -458,7 +458,7 @@ fn pk_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) -> Tokens {
     let mut primary_key = None;
     for field in named {
         let typ = token_to_string(&field.ty);
-        if let Some(ident) = field.ident {
+        if let Some(ref ident) = field.ident {
             if typ == "PrimaryKey" {
                 primary_key = Some(ident);
             }
@@ -488,7 +488,7 @@ fn check_missing_fields_macro(named: &Punctuated<Field, Comma>, table_ident: &Id
     let mut mandatory_fields = vec![];
     for field in named {
         let typ = token_to_string(&field.ty);
-        if let Some(ident) = field.ident {
+        if let Some(ref ident) = field.ident {
             if !typ.starts_with("Option") && typ != "PrimaryKey" {
                 mandatory_fields.push(ident);
             }
@@ -521,7 +521,7 @@ fn related_table_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) ->
     let mut compiler_errors = vec![];
     for field in named {
         let typ = token_to_string(&field.ty);
-        if let Some(ident) = field.ident {
+        if let Some(ref ident) = field.ident {
             if typ.starts_with("ForeignKey") {
                 if let syn::Type::Path(ref path) = field.ty {
                     let element = path.path.segments.first().expect("first segment of path");
@@ -617,7 +617,7 @@ pub fn table_macro(item_struct: &ItemStruct) -> Tokens {
         let mut fk_patterns = vec![];
         for field in named {
             let typ = token_to_string(&field.ty);
-            if let Some(ident) = field.ident {
+            if let Some(ref ident) = field.ident {
                 if !typ.starts_with("Option") && typ != "PrimaryKey" {
                     mandatory_fields.push(ident);
                 }

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -109,6 +109,7 @@ pub fn table_methods(item_struct: &ItemStruct) -> Tokens {
             .map(|field| field.ident.clone().expect("field has name"));
         let field_idents2 = named.iter()
             .map(|field| field.ident.clone().expect("field has name"));
+
         let trait_ident = quote_spanned! { table_ident.span() =>
             ::tql::SqlTable
         };
@@ -543,8 +544,7 @@ fn related_table_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) ->
                 let msg = string_literal(&format!("mismatched types
 expected type `ForeignKey<_>`
    found type `{}`", typ));
-                let span = crate::merge_spans_of(&field);
-                compiler_errors.push(quote_spanned! { span =>
+                compiler_errors.push(quote_spanned! { field.span() =>
                     compile_error!(#msg)
                 });
             }

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -28,7 +28,7 @@ mod sqlite;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use proc_macro2::TokenStream as Tokens; // todo: remove
+use proc_macro2::TokenStream as Tokens;
 use rand::{self, Rng};
 use syn::{
     self,

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -109,7 +109,6 @@ pub fn table_methods(item_struct: &ItemStruct) -> Tokens {
             .map(|field| field.ident.clone().expect("field has name"));
         let field_idents2 = named.iter()
             .map(|field| field.ident.clone().expect("field has name"));
-
         let trait_ident = quote_spanned! { table_ident.span() =>
             ::tql::SqlTable
         };
@@ -544,7 +543,8 @@ fn related_table_macro(named: &Punctuated<Field, Comma>, table_ident: &Ident) ->
                 let msg = string_literal(&format!("mismatched types
 expected type `ForeignKey<_>`
    found type `{}`", typ));
-                compiler_errors.push(quote_spanned! { field.span() =>
+                let span = crate::merge_spans_of(&field);
+                compiler_errors.push(quote_spanned! { span =>
                     compile_error!(#msg)
                 });
             }

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -40,7 +40,9 @@ use syn::{
     ItemStruct,
     parse,
 };
-use syn::{AngleBracketedGenericArguments, LitStr, Path, TypePath};
+#[cfg(feature="unstable")]
+use syn::LitStr;
+use syn::{AngleBracketedGenericArguments, Path, TypePath};
 use syn::PathArguments::AngleBracketed;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -77,8 +79,6 @@ use {
     empty_token_stream,
     typecheck_arguments,
 };
-#[cfg(feature = "unstable")]
-use respan_with;
 
 /// Create the from_row() method for the table struct.
 pub fn table_methods(item_struct: &ItemStruct) -> Tokens {

--- a/tql_macros/src/gen/mod.rs
+++ b/tql_macros/src/gen/mod.rs
@@ -40,9 +40,7 @@ use syn::{
     ItemStruct,
     parse,
 };
-#[cfg(feature = "unstable")]
 use syn::{AngleBracketedGenericArguments, LitStr, Path, TypePath};
-#[cfg(feature = "unstable")]
 use syn::PathArguments::AngleBracketed;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -109,7 +107,7 @@ pub fn table_methods(item_struct: &ItemStruct) -> Tokens {
             .map(|field| field.ident.clone().expect("field has name"));
         let field_idents2 = named.iter()
             .map(|field| field.ident.clone().expect("field has name"));
-
+        
         let trait_ident = quote_spanned! { table_ident.span() =>
             ::tql::SqlTable
         };
@@ -284,6 +282,7 @@ fn gen_aggregate_struct(aggregates: &[Aggregate]) -> (Tokens, Tokens) {
     }})
 }
 
+
 /// Get the fields from the struct (also returns the ToSql implementations to check that the types
 /// used for ForeignKey have a #[derive(SqlTable)]).
 /// Also check if the field types from the struct are supported types.
@@ -306,7 +305,6 @@ pub fn get_struct_fields(item_struct: &ItemStruct) -> (Result<SqlFields>, Option
     let mut primary_key_count = 0;
     for field in &fields {
         if let Some(ref field_ident) = field.ident {
-            #[cfg(feature = "unstable")]
             let field_type = &field.ty;
             let field_name = field_ident.to_string();
             let field = field_ty_to_type(&field.ty);
@@ -327,38 +325,30 @@ pub fn get_struct_fields(item_struct: &ItemStruct) -> (Result<SqlFields>, Option
                     let type_ident = new_ident(typ);
                     let struct_ident = new_ident(&format!("CheckForeignKey{}", rand_string()));
                     // TODO: replace with a trait bound on ForeignKey when it is stable.
-                    #[cfg(feature = "unstable")]
-                    let mut code: TokenStream;
-                    #[cfg(not(feature = "unstable"))]
-                    let code: TokenStream;
-                    code = quote! {
+                    let span = {
+                        if let syn::Type::Path(TypePath { path: Path { ref segments, .. }, ..}) = *field_type {
+                            let segment = segments.first().expect("first segment").into_value();
+                            if let AngleBracketed(AngleBracketedGenericArguments { ref args, .. }) =
+                                segment.arguments
+                            {
+                                args.first().expect("first argument").span()
+                            }
+                            else {
+                                field_type.span()
+                            }
+                        }
+                        else {
+                            field_type.span()
+                        }
+                    };
+
+                    let code: TokenStream = quote_spanned!{ span =>
                         #[allow(dead_code)]
                         struct #struct_ident where #type_ident: ::tql::SqlTable {
                             field: #type_ident,
                         }
                     }.into();
-                    #[cfg(feature = "unstable")]
-                    {
-                        let field_pos =
-                            if let syn::Type::Path(TypePath { path: Path { ref segments, .. }, ..}) = *field_type {
-                                let segment = segments.first().expect("first segment").into_value();
-                                if let AngleBracketed(AngleBracketedGenericArguments { ref args, .. }) =
-                                    segment.arguments
-                                {
-                                    args.first().expect("first argument").span()
-                                }
-                                else {
-                                    field_type.span()
-                                }
-                            }
-                            else {
-                                field_type.span()
-                            };
-                        let span = field_pos.unstable();
-                        // NOTE: position the trait at this position so that the error message points
-                        // on the type.
-                        code = respan_with(code, span);
-                    }
+
                     impls = concat_token_stream(impls, code);
                 },
                 _ => (),

--- a/tql_macros/src/gen/postgres.rs
+++ b/tql_macros/src/gen/postgres.rs
@@ -56,7 +56,7 @@ impl BackendGen for PostgresBackend {
     fn gen_query_expr(&self, connection_expr: TokenStream, args: &SqlQueryWithArgs, args_expr: TokenStream, struct_expr: TokenStream,
                       aggregate_struct: TokenStream, aggregate_expr: TokenStream) -> TokenStream
     {
-        let result_ident = Ident::new("result", proc_macro2::Span::call_site());
+        let result_ident = Ident::new("__tql_result", proc_macro2::Span::call_site());
         let sql_query = &args.sql;
         let std_ident = quote_spanned! { connection_expr.span() =>
             ::std

--- a/tql_macros/src/gen/postgres.rs
+++ b/tql_macros/src/gen/postgres.rs
@@ -19,8 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-use proc_macro2::Span;
-use quote::Tokens;
+use proc_macro2::{Span,TokenStream};
 use syn::{
     Expr,
     ExprLit,
@@ -43,21 +42,21 @@ pub fn create_backend() -> PostgresBackend {
 }
 
 impl BackendGen for PostgresBackend {
-    fn convert_index(&self, index: usize) -> Tokens {
+    fn convert_index(&self, index: usize) -> TokenStream {
         quote! {
             #index
         }
     }
 
-    fn delta_type(&self) -> Tokens {
+    fn delta_type(&self) -> TokenStream {
         quote! { usize }
     }
 
     /// Generate the Rust code using the `postgres` library depending on the `QueryType`.
-    fn gen_query_expr(&self, connection_expr: Tokens, args: &SqlQueryWithArgs, args_expr: Tokens, struct_expr: Tokens,
-                      aggregate_struct: Tokens, aggregate_expr: Tokens) -> Tokens
+    fn gen_query_expr(&self, connection_expr: TokenStream, args: &SqlQueryWithArgs, args_expr: TokenStream, struct_expr: TokenStream,
+                      aggregate_struct: TokenStream, aggregate_expr: TokenStream) -> TokenStream
     {
-        let result_ident = Ident::from("result");
+        let result_ident = Ident::new("result", proc_macro2::Span::call_site());
         let sql_query = &args.sql;
         let std_ident = quote_spanned! { connection_expr.span() =>
             ::std
@@ -149,19 +148,19 @@ impl BackendGen for PostgresBackend {
         })
     }
 
-    fn row_type_ident(&self, table_ident: &Ident) -> Tokens {
+    fn row_type_ident(&self, table_ident: &Ident) -> proc_macro2::TokenStream {
         quote_spanned! { table_ident.span() =>
             ::postgres::rows::Row
         }
     }
 
-    fn to_sql(&self, primary_key_ident: &Ident) -> Tokens {
+    fn to_sql(&self, primary_key_ident: &Ident) -> proc_macro2::TokenStream {
         quote! {
             self.#primary_key_ident.to_sql(ty, out)
         }
     }
 
-    fn to_sql_impl(&self, table_ident: &Ident, to_sql_code: Tokens) -> Tokens {
+    fn to_sql_impl(&self, table_ident: &Ident, to_sql_code: proc_macro2::TokenStream) -> TokenStream {
         let std_ident = quote_spanned! { table_ident.span() =>
             ::std
         };

--- a/tql_macros/src/gen/sqlite.rs
+++ b/tql_macros/src/gen/sqlite.rs
@@ -56,7 +56,7 @@ impl BackendGen for SqliteBackend {
     fn gen_query_expr(&self, connection_expr: TokenStream, args: &SqlQueryWithArgs, args_expr: TokenStream, struct_expr: TokenStream,
                       aggregate_struct: TokenStream, aggregate_expr: TokenStream) -> TokenStream
     {
-        let result_ident = Ident::new("result",Span::call_site());
+        let result_ident = Ident::new("__tql_result",Span::call_site());
         let sql_query = &args.sql;
         let rusqlite_ident = quote_spanned! { connection_expr.span() =>
             ::rusqlite

--- a/tql_macros/src/gen/sqlite.rs
+++ b/tql_macros/src/gen/sqlite.rs
@@ -19,8 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-use proc_macro2::Span;
-use quote::Tokens;
+use proc_macro2::{Span,TokenStream};
 use syn::{
     Expr,
     ExprLit,
@@ -43,21 +42,21 @@ pub fn create_backend() -> SqliteBackend {
 }
 
 impl BackendGen for SqliteBackend {
-    fn convert_index(&self, index: usize) -> Tokens {
+    fn convert_index(&self, index: usize) -> TokenStream {
         let index = index as i32;
         quote! {
             #index
         }
     }
 
-    fn delta_type(&self) -> Tokens {
+    fn delta_type(&self) -> TokenStream {
         quote! { i32 }
     }
 
-    fn gen_query_expr(&self, connection_expr: Tokens, args: &SqlQueryWithArgs, args_expr: Tokens, struct_expr: Tokens,
-                      aggregate_struct: Tokens, aggregate_expr: Tokens) -> Tokens
+    fn gen_query_expr(&self, connection_expr: TokenStream, args: &SqlQueryWithArgs, args_expr: TokenStream, struct_expr: TokenStream,
+                      aggregate_struct: TokenStream, aggregate_expr: TokenStream) -> TokenStream
     {
-        let result_ident = Ident::from("result");
+        let result_ident = Ident::new("result",Span::call_site());
         let sql_query = &args.sql;
         let rusqlite_ident = quote_spanned! { connection_expr.span() =>
             ::rusqlite
@@ -145,19 +144,19 @@ impl BackendGen for SqliteBackend {
         })
     }
 
-    fn row_type_ident(&self, table_ident: &Ident) -> Tokens {
+    fn row_type_ident(&self, table_ident: &Ident) -> TokenStream {
         quote_spanned! { table_ident.span() =>
             ::rusqlite::Row
         }
     }
 
-    fn to_sql(&self, primary_key_ident: &Ident) -> Tokens {
+    fn to_sql(&self, primary_key_ident: &Ident) -> TokenStream {
         quote! {
             self.#primary_key_ident.to_sql()
         }
     }
 
-    fn to_sql_impl(&self, table_ident: &Ident, to_sql_code: Tokens) -> Tokens {
+    fn to_sql_impl(&self, table_ident: &Ident, to_sql_code: TokenStream) -> TokenStream {
         let rusqlite_ident = quote_spanned! { table_ident.span() =>
             ::rusqlite
         };

--- a/tql_macros/src/lib.rs
+++ b/tql_macros/src/lib.rs
@@ -75,7 +75,7 @@
  * explain why it is slow.
  */
 
-#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic, proc_macro_span))]
+#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 #![recursion_limit="128"]
 
 #[cfg(all(feature = "rusqlite", feature = "postgres"))]
@@ -516,6 +516,7 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
             _data = #expr;
         });
     }
+
     let trait_ident = quote_spanned! { table_ident.span() =>
         ::tql::SqlTable
     };
@@ -680,26 +681,4 @@ pub fn stable_to_sql(input: TokenStream) -> TokenStream {
     }
 
     empty_token_stream()
-}
-
-#[cfg(feature="unstable")]
-pub(crate) fn merge_spans_of<T: quote::ToTokens>(tokens: &T) -> proc_macro2::Span {
-    let ts = quote::ToTokens::into_token_stream(tokens.clone());
-    let spans : Vec<proc_macro::Span> = ts.into_iter()
-    .map(|x| x.span().unwrap())
-    .collect();
-    let first = spans[0].clone();
-    let merged = spans.iter().fold(first, |acc,x| acc.join(x.clone()).unwrap());
-    merged.into()
-}
-
-//TODO: remove this version when proc_macro::Span::join is stable
-#[cfg(not(feature="unstable"))]
-pub(crate) fn merge_spans_of<T: quote::ToTokens>(tokens: &T) -> proc_macro2::Span {
-    //on stable its impossible to merge spans, so this does not but just takes first
-    let ts = quote::ToTokens::into_token_stream(tokens.clone());
-    ts.into_iter()
-    .map(|x| x.span())
-    .nth(0)
-    .unwrap()
 }

--- a/tql_macros/src/lib.rs
+++ b/tql_macros/src/lib.rs
@@ -75,7 +75,7 @@
  * explain why it is slow.
  */
 
-#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
+#![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic, proc_macro_span))]
 #![recursion_limit="128"]
 
 #[cfg(all(feature = "rusqlite", feature = "postgres"))]
@@ -516,7 +516,6 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
             _data = #expr;
         });
     }
-
     let trait_ident = quote_spanned! { table_ident.span() =>
         ::tql::SqlTable
     };
@@ -681,4 +680,26 @@ pub fn stable_to_sql(input: TokenStream) -> TokenStream {
     }
 
     empty_token_stream()
+}
+
+#[cfg(feature="unstable")]
+pub(crate) fn merge_spans_of<T: quote::ToTokens>(tokens: &T) -> proc_macro2::Span {
+    let ts = quote::ToTokens::into_token_stream(tokens.clone());
+    let spans : Vec<proc_macro::Span> = ts.into_iter()
+    .map(|x| x.span().unwrap())
+    .collect();
+    let first = spans[0].clone();
+    let merged = spans.iter().fold(first, |acc,x| acc.join(x.clone()).unwrap());
+    merged.into()
+}
+
+//TODO: remove this version when proc_macro::Span::join is stable
+#[cfg(not(feature="unstable"))]
+pub(crate) fn merge_spans_of<T: quote::ToTokens>(tokens: &T) -> proc_macro2::Span {
+    //on stable its impossible to merge spans, so this does not but just takes first
+    let ts = quote::ToTokens::into_token_stream(tokens.clone());
+    ts.into_iter()
+    .map(|x| x.span())
+    .nth(0)
+    .unwrap()
 }

--- a/tql_macros/src/lib.rs
+++ b/tql_macros/src/lib.rs
@@ -113,7 +113,7 @@ use proc_macro::TokenStream;
 #[cfg(feature = "unstable")]
 use proc_macro::{Group, TokenTree};
 use proc_macro2::{Spacing, Span};
-use proc_macro2::TokenStream as Tokens; // TODO: remove
+use proc_macro2::TokenStream as Tokens;
 
 use syn::{
     Expr,
@@ -374,7 +374,6 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
     #[cfg(feature = "unstable")]
     let metavars = vec![];
     let mut next_name = (0..).map(|counter|
-        //Ident::from(format!("__tql_arg{}", counter))
         Ident::new(&format!("__tql_arg{}", counter), Span::call_site())
     );
 
@@ -625,8 +624,7 @@ pub fn stable_to_sql(input: TokenStream) -> TokenStream {
                 if let Expr::Macro(ref macr) = **tuple.elems.first().unwrap().value() {
                     let tts: Vec<_> = macr.mac.tts.clone().into_iter().collect();
                     let (sql_query, connection_expr) =
-                        //if let proc_macro2::TokenTree::Op(op) = tts[1] {
-                        if let proc_macro2::TokenTree::Punct(ref op) = tts[1] { //TODO: check
+                        if let proc_macro2::TokenTree::Punct(ref op) = tts[1] { 
                             if op.as_char() == ',' && op.spacing() == Spacing::Alone {
                                 let connection_expr = &tts[0];
                                 let connection_expr = quote! {

--- a/tql_macros/src/lib.rs
+++ b/tql_macros/src/lib.rs
@@ -114,8 +114,7 @@ use proc_macro::TokenStream;
 use proc_macro::{Group, TokenTree};
 use proc_macro2::{Spacing, Span};
 use proc_macro2::TokenStream as Tokens; // TODO: remove
-#[cfg(feature = "unstable")]
-//use quote::ToTokens;
+
 use syn::{
     Expr,
     Ident,
@@ -400,7 +399,7 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
                 let convert_ident = Ident::new("convert", arg.expression.span());
                 let to_owned_ident = Ident::new("to_owned", Span::call_site());
                 #[cfg(not(feature = "unstable"))]
-                let expr = arg_name.map(|arg_name| quote! { #arg_name }).unwrap_or_else(|| {
+                let expr = arg_name.clone().map(|arg_name| quote! { #arg_name }).unwrap_or_else(|| {
                     let expr = &arg.expression;
                     quote! { #expr }
                 });

--- a/tql_macros/src/lib.rs
+++ b/tql_macros/src/lib.rs
@@ -377,7 +377,7 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
         Ident::new(&format!("__tql_arg{}", counter), Span::call_site())
     );
 
-    let ident = Ident::new("_table", Span::call_site());
+    let ident = Ident::new("__tql_table", Span::call_site());
     {
         let mut add_arg = |arg: &Arg| {
             let arg_name =
@@ -395,7 +395,7 @@ fn typecheck_arguments(args: &SqlQueryWithArgs) -> (Tokens, Vec<Tokens>) {
                     Ident::new(&name[index..], pos)
                 })
             {
-                let convert_ident = Ident::new("convert", arg.expression.span());
+                let convert_ident = Ident::new("__tql_convert", arg.expression.span());
                 let to_owned_ident = Ident::new("to_owned", Span::call_site());
                 #[cfg(not(feature = "unstable"))]
                 let expr = arg_name.clone().map(|arg_name| quote! { #arg_name }).unwrap_or_else(|| {

--- a/tql_macros/src/parser.rs
+++ b/tql_macros/src/parser.rs
@@ -110,7 +110,7 @@ impl Parser {
                 _ => {
                     errors.push(Error::new(
                         "Expected method call", // TODO: improve this message.
-                        crate::merge_spans_of(expr),
+                        expr.span(),
                     ));
                 }
             }

--- a/tql_macros/src/parser.rs
+++ b/tql_macros/src/parser.rs
@@ -110,7 +110,7 @@ impl Parser {
                 _ => {
                     errors.push(Error::new(
                         "Expected method call", // TODO: improve this message.
-                        expr.span(),
+                        crate::merge_spans_of(expr),
                     ));
                 }
             }

--- a/tql_macros/src/parser.rs
+++ b/tql_macros/src/parser.rs
@@ -87,7 +87,7 @@ impl Parser {
                         .collect();
 
                     calls.push(MethodCall {
-                        name: call.method,
+                        name: call.method.clone(),
                         args,
                         position: expr.span(),
                     });
@@ -96,7 +96,7 @@ impl Parser {
                     if path.path.segments.len() == 1 {
                         calls.name = Some(path.path.segments.first()
                             .expect("first segment in path").into_value()
-                            .ident);
+                            .ident.clone());
                     }
                 },
                 Expr::Index(ref index) => {

--- a/tql_macros/src/sql/dummy.rs
+++ b/tql_macros/src/sql/dummy.rs
@@ -21,7 +21,7 @@
 
 //! The SQLite code generator.
 
-use quote::Tokens;
+use proc_macro2::TokenStream ;
 
 use ast::Aggregate;
 use sql::{SqlBackend, ToSql};
@@ -39,7 +39,7 @@ impl ToSql for Aggregate {
 }
 
 impl SqlBackend for DummySqlBackend {
-    fn insert_query(&self, _table: &str, _fields: &[String], _values: &[String]) -> Tokens {
+    fn insert_query(&self, _table: &str, _fields: &[String], _values: &[String]) -> TokenStream {
         unreachable!("Enable one of the following features: sqlite, pg");
     }
 }

--- a/tql_macros/src/sql/postgres.rs
+++ b/tql_macros/src/sql/postgres.rs
@@ -21,8 +21,7 @@
 
 //! The PostgreSQL code generator.
 
-use proc_macro2::Span;
-use quote::Tokens;
+use proc_macro2::{Span,TokenStream};
 use syn::Ident;
 
 use ast::Aggregate;
@@ -38,12 +37,12 @@ impl ToSql for Aggregate {
     fn to_sql(&self, index: &mut usize) -> String {
         // TODO: do not hard-code the type.
         "CAST(".to_string() + &self.sql_function.to_sql(index) + "(" +
-            &self.field.expect("Aggregate field").to_sql(index) + ") AS DOUBLE PRECISION)"
+            &self.field.clone().expect("Aggregate field").to_sql(index) + ") AS DOUBLE PRECISION)"
     }
 }
 
 impl SqlBackend for PostgresSqlBackend {
-    fn insert_query(&self, table: &str, fields: &[String], values: &[String]) -> Tokens {
+    fn insert_query(&self, table: &str, fields: &[String], values: &[String]) -> TokenStream {
         let query_start =
             format!("INSERT INTO {table}({fields}) VALUES({values}) RETURNING ",
             table = table,

--- a/tql_macros/src/sql/sqlite.rs
+++ b/tql_macros/src/sql/sqlite.rs
@@ -21,7 +21,7 @@
 
 //! The SQLite code generator.
 
-use quote::Tokens;
+use proc_macro2::TokenStream;
 
 use ast::Aggregate;
 use sql::{SqlBackend, ToSql};
@@ -34,12 +34,12 @@ pub fn create_sql_backend() -> SqliteSqlBackend {
 
 impl ToSql for Aggregate {
     fn to_sql(&self, index: &mut usize) -> String {
-        self.sql_function.to_sql(index) + "(" + &self.field.expect("Aggregate field").to_sql(index) + ")"
+        self.sql_function.to_sql(index) + "(" + &self.field.clone().expect("Aggregate field").to_sql(index) + ")"
     }
 }
 
 impl SqlBackend for SqliteSqlBackend {
-    fn insert_query(&self, table: &str, fields: &[String], values: &[String]) -> Tokens {
+    fn insert_query(&self, table: &str, fields: &[String], values: &[String]) -> TokenStream {
         let query =
             format!("INSERT INTO {table}({fields}) VALUES({values})",
             table = table,

--- a/tql_macros/src/types.rs
+++ b/tql_macros/src/types.rs
@@ -21,7 +21,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
-use quote::Tokens;
+use proc_macro2::TokenStream;
 use syn::{
     self,
     AngleBracketedGenericArguments,
@@ -94,7 +94,7 @@ impl Display for Type {
 }
 
 /// Convert a `Type` to its SQL representation.
-pub fn type_to_sql(typ: &Type) -> Tokens {
+pub fn type_to_sql(typ: &Type) -> TokenStream {
     sql::type_to_sql(typ, false)
 }
 


### PR DESCRIPTION
This pr attempts to build this lib on the  nightly-2019-03-14 version of rust.

proc_macro crate had some breaking changes since last commit, so proc_macro2 along with quote and syn are updated, and tql_macros is migrated to new version of syn and quote. Unfortunetly, using sql! macro still requires feature gate (proc_macro_hygiene).

There are currently 2 things left: 
* tests/select_expr.rs fails to build, due to this line: `let table = sql!(TableSelectExpr[result()]).unwrap();` .It seems that cause of it is independent of this pr – when i tried to build master branch on some old nighties (like nightly-2018-04-15) i got the same error. When this line and assosiated assertion is removed, tests work fine. Is it ok to skip this in this pr? 
* for now, i only fixed compile tests that had trivial errors (just way that those errors are presented  by compiler is slightly diffrent). I am unsure about remaining ones. Majority of them fail because rustc detects more errors, like ` missing extern crate rusqlite` or `cannot find value connection` - is it better to just fix those additional errors, or add them to *.stderr file ? . For other cases error message is somehow difrent or error span slightly changed - i yet have to look into it